### PR TITLE
fix: Allow training bagel on understanding dataset when `visual_gen=True`

### DIFF
--- a/src/lmms_engine/models/bagel/bagel.py
+++ b/src/lmms_engine/models/bagel/bagel.py
@@ -17,7 +17,6 @@ from torch.nn.attention.flex_attention import create_block_mask
 from tqdm import tqdm
 from transformers.configuration_utils import PretrainedConfig
 from transformers.modeling_utils import PreTrainedModel
-from loguru import logger
 
 from .autoencoder import AutoEncoder, AutoEncoderParams, load_ae
 from .cache_utils import cache_init
@@ -270,7 +269,7 @@ class Bagel(PreTrainedModel):
             size=(sequence_length, self.hidden_size)
         )
         packed_sequence[packed_text_indexes] = packed_text_embedding
-        
+
         need_visual_gen = self.config.visual_gen and padded_latent is not None
         need_visual_und = self.config.visual_und and packed_vit_tokens is not None
 
@@ -1389,7 +1388,6 @@ class Bagel(PreTrainedModel):
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, config, *args, **kwargs):
         ema_path = os.path.join(pretrained_model_name_or_path, "ema.safetensors")
-        logger.info(f"config: {config}")
         if not os.path.exists(ema_path):
             return super().from_pretrained(
                 pretrained_model_name_or_path, config, *args, **kwargs


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code
- [ ] Add unit tests
- [ ] Update documentation as needed, including docstrings or example tutorials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined visual generation and understanding to run only when relevant inputs are present, reducing unnecessary computation.
  * Improves inference/training performance and lowers memory usage without changing results when no visual inputs are provided.
  * Leads to faster response times and more efficient resource utilization in visual workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->