### PR TITLE
[fix] Update Hydra command for multi-node training

### DIFF
--- a/docs/models/qwenvl.md
+++ b/docs/models/qwenvl.md
@@ -375,10 +375,10 @@ torchrun --nproc_per_node=8 \
     --master_addr=<MASTER_NODE_IP> \
     --master_port=8000 \
     -m lmms_engine.launch.cli config_yaml=${CONFIG} \
-    hydra.output_subdir=null
+    hydra.output_subdir=null hydra/job_logging=disabled
 ```
 
-In multi-node training, simultaneous starts cause Hydra conflicts due to [timestamped working directories](https://hydra.cc/docs/configure_hydra/workdir/). Use `hydra.output_subdir=null` to fix this.
+In multi-node training, simultaneous starts cause Hydra conflicts due to [timestamped working directories](https://hydra.cc/docs/configure_hydra/workdir/). Use `hydra.output_subdir=null` and `hydra/job_logging=disabled` to fix this.
 
 ## Model Architecture Details
 


### PR DESCRIPTION
Added 'hydra/job_logging=disabled' to the command to prevent Hydra conflicts during multi-node training.