### PR TITLE
[fix] relax overwrite_config typing to support non-string config overrides

### DIFF
--- a/src/lmms_engine/models/config.py
+++ b/src/lmms_engine/models/config.py
@@ -8,5 +8,5 @@ class ModelConfig(Args):
     load_from_pretrained_path: Optional[str] = None
     load_from_config: Optional[Dict[str, Any]] = None
     attn_implementation: Optional[Literal["flash_attention_2", "sdpa", "eager"]] = "sdpa"
-    overwrite_config: Optional[Dict[str, str]] = None
+    overwrite_config: Optional[Dict[str, Any]] = None
     monkey_patch_kwargs: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Motivation

`overwrite_config` is used to override Hugging Face model config values, which can be non-string types (e.g., bool/int/float/dict). The previous type annotation (`Optional[Dict[str, str]]`) was too restrictive and could cause type-checking friction.

## Modifications

- Updated `overwrite_config` in `src/lmms_engine/models/config.py` from `Optional[Dict[str, str]]` to `Optional[Dict[str, Any]]` to support arbitrary config value types.