### PR TITLE
fix(dataset): join data_folder with video path in Qwen3VL iterable dataset

### DIFF
--- a/src/lmms_engine/datasets/iterable/qwen3_vl_iterable_dataset.py
+++ b/src/lmms_engine/datasets/iterable/qwen3_vl_iterable_dataset.py
@@ -59,6 +59,8 @@ class Qwen3VLIterableDataset(VisionSFTIterableDataset):
         assert (
             self.config.video_backend == "qwen_vl_utils"
         ), "Qwen3VLIterableDataset only supports qwen_vl_utils backend"
+        if data_folder is not None:
+            video_path = os.path.join(data_folder, video_path)
         frames, video_metadata, sample_fps = self.load_video_qwen_vl_utils(video_path, fps)
         return frames, video_metadata, sample_fps
 


### PR DESCRIPTION
## Summary

- **Fix**: `Qwen3VLIterableDataset.load_videos()` receives `data_folder` but never joins it with the relative `video_path` before passing to `load_video_qwen_vl_utils()`. This causes `file://` URLs to use bare relative paths (e.g. `file://academic_source/Charades/028CE.mp4`) that fail to resolve.
- **Root cause**: The overridden `load_videos()` in `qwen3_vl_iterable_dataset.py` skips the `os.path.join(data_folder, video_path)` step that the base mixin and the naive `qwen3_vl_dataset.py` both perform correctly.
- **Fix**: Add the 2-line `data_folder` join at the top of `load_videos()`, consistent with every other dataset implementation.