### PR TITLE
chore: add Dockerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,75 @@
+# Git directory (contains tokens in remote URL)
+.git
+.gitignore
+
+# Local directories (from .gitignore)
+data/
+scripts/
+wandb/
+playground/
+output/
+outputs/
+trainer_output/
+checkpoints/
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+*.egg
+*.so
+*.pth
+build/
+dist/
+develop-eggs/
+.eggs/
+sdist/
+wheels/
+MANIFEST
+
+# Environments
+.env
+.venv
+venv/
+env/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE / editor
+.vscode
+.idea/
+
+# Testing / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.nox/
+.hypothesis/
+cover/
+nosetests.xml
+coverage.xml
+
+# Documentation build
+docs/_build/
+
+# Type checkers
+.mypy_cache/
+.dmypy.json
+.pytype/
+.pyre/
+
+# Misc
+.DS_Store
+*.log
+.deepspeed_env
+cython_debug/
+.ipynb_checkpoints
+.cache
+
+# Docker
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM pytorch/pytorch:2.9.1-cuda12.8-cudnn9-devel
+
+# System dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ffmpeg \
+    libsndfile1 \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    ninja-build \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv for fast package management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+WORKDIR /workspace
+
+# Copy source (filtered by .dockerignore)
+COPY . .
+
+# Install lmms-engine with all extras, flash-attn, and liger-kernel
+RUN uv pip install --system -e ".[all]" && \
+    uv pip install --system flash-attn --no-build-isolation && \
+    uv pip install --system liger-kernel


### PR DESCRIPTION
## Summary
- Add `Dockerfile` based on `pytorch/pytorch:2.9.1-cuda12.8-cudnn9-devel` with system deps (ffmpeg, libsndfile1, libgl1, ninja), uv for fast package management, flash-attn, and liger-kernel
- Add `.dockerignore` to exclude `.git/` (token safety), `data/`, `scripts/`, `wandb/`, `output/`, `outputs/`, and Python/IDE artifacts from the build context