### PR TITLE
fix(merger): copy processor_config.json for custom processors

### DIFF
--- a/src/lmms_engine/merger/fsdp2.py
+++ b/src/lmms_engine/merger/fsdp2.py
@@ -1,6 +1,7 @@
 """FSDP2 checkpoint merger implementation."""
 
 import os
+import shutil
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Literal
@@ -198,5 +199,12 @@ class FSDP2Merger(CheckpointMerger):
         config.save_pretrained(output_path)
         # Save merged checkpoint
         model.save_pretrained(output_path)
+
+        # Copy over any extra config files that AutoProcessor may not handle
+        # (e.g. processor_config.json for custom processors)
+        for extra_file in ["processor_config.json"]:
+            src = checkpoint_path / extra_file
+            if src.exists():
+                shutil.copy2(src, output_path / extra_file)
 
         return output_path


### PR DESCRIPTION
## Summary

`AutoProcessor.from_pretrained` does not recognize custom processors (e.g. `AeroRealtimeProcessor`) and falls back to the base `Qwen2Tokenizer`, so `save_pretrained` only emits tokenizer files and misses `processor_config.json`.

- Copy `processor_config.json` from the source checkpoint directory if it exists