### PR TITLE
fix(fsdp2): avoid double-dividing tokens_per_gpu by sp_size

### DIFF
--- a/src/lmms_engine/train/fsdp2/fsdp2_trainer.py
+++ b/src/lmms_engine/train/fsdp2/fsdp2_trainer.py
@@ -669,7 +669,7 @@ class FSDP2SFTTrainer:
         total_tokens += total_seq_len.item()
 
         tokens_per_second = total_seq_len.item() / delta_time
-        tokens_per_gpu = tokens_per_second / sp_size / world_size
+        tokens_per_gpu = tokens_per_second / world_size
 
         # Log total tokens and total tokens per second
         metrics["train/total_tokens"] = TrainUtilities.format_tokens(total_tokens)


### PR DESCRIPTION
## Summary
- `total_seq_len` is already divided by `sp_size` before the `all_reduce(SUM)` across the full world, so dividing `tokens_per_second` by both `sp_size` and `world_size` underestimates `tokens_per_gpu` by a factor of `sp_size` whenever sequence parallelism is enabled.
- Drop the redundant `/ sp_size` so per-GPU throughput reflects reality.