### PR TITLE
fix(qwen3_vl): apply pixel limits via processor size

### DIFF
--- a/src/lmms_engine/datasets/processor/base_qwen2_5_processor.py
+++ b/src/lmms_engine/datasets/processor/base_qwen2_5_processor.py
@@ -16,6 +16,23 @@ class BaseQwen2_5_DataProcessor(AeroDataProcessor):
     def _build_processor(self):
         raise NotImplementedError("This method should be implemented in subclasses.")
 
+    @staticmethod
+    def _set_vision_processor_size(processor, min_pixels=None, max_pixels=None):
+        if processor is None or (min_pixels is None and max_pixels is None):
+            return
+
+        size = getattr(processor, "size", None) or {}
+        if hasattr(size, "to_dict"):
+            size = size.to_dict()
+        else:
+            size = dict(size)
+
+        if min_pixels is not None:
+            size["shortest_edge"] = min_pixels
+        if max_pixels is not None:
+            size["longest_edge"] = max_pixels
+        processor.size = size
+
     def process(
         self,
         images: List[Image.Image],

--- a/src/lmms_engine/datasets/processor/qwen2_5_omni_processor.py
+++ b/src/lmms_engine/datasets/processor/qwen2_5_omni_processor.py
@@ -22,18 +22,12 @@ class Qwen2_5OmniDataProcessor(BaseQwen2_5_DataProcessor):
         # Set image processor parameters
         image_max_pixels = self.config.extra_kwargs.get("image_max_pixels", None)
         image_min_pixels = self.config.extra_kwargs.get("image_min_pixels", None)
-        if image_max_pixels:
-            processor.image_processor.max_pixels = image_max_pixels
-        if image_min_pixels:
-            processor.image_processor.min_pixels = image_min_pixels
+        self._set_vision_processor_size(processor.image_processor, image_min_pixels, image_max_pixels)
 
         # Set video processor parameters
         video_max_pixels = self.config.extra_kwargs.get("video_max_pixels", None)
         video_min_pixels = self.config.extra_kwargs.get("video_min_pixels", None)
-        if video_max_pixels:
-            processor.video_processor.max_pixels = video_max_pixels
-        if video_min_pixels:
-            processor.video_processor.min_pixels = video_min_pixels
+        self._set_vision_processor_size(processor.video_processor, video_min_pixels, video_max_pixels)
 
         # Set audio processor parameters
         audio_max_length = self.config.extra_kwargs.get("audio_max_length", None)

--- a/src/lmms_engine/datasets/processor/qwen2_5_vl_processor.py
+++ b/src/lmms_engine/datasets/processor/qwen2_5_vl_processor.py
@@ -17,18 +17,12 @@ class Qwen2_5_VLDataProcessor(BaseQwen2_5_DataProcessor):
         # Set image processor parameters
         image_max_pixels = self.config.extra_kwargs.get("image_max_pixels", None)
         image_min_pixels = self.config.extra_kwargs.get("image_min_pixels", None)
-        if image_max_pixels:
-            processor.image_processor.max_pixels = image_max_pixels
-        if image_min_pixels:
-            processor.image_processor.min_pixels = image_min_pixels
+        self._set_vision_processor_size(processor.image_processor, image_min_pixels, image_max_pixels)
 
         # Set video processor parameters
         video_max_pixels = self.config.extra_kwargs.get("video_max_pixels", None)
         video_min_pixels = self.config.extra_kwargs.get("video_min_pixels", None)
-        if video_max_pixels:
-            processor.video_processor.max_pixels = video_max_pixels
-        if video_min_pixels:
-            processor.video_processor.min_pixels = video_min_pixels
+        self._set_vision_processor_size(processor.video_processor, video_min_pixels, video_max_pixels)
         return processor
 
     def process(

--- a/src/lmms_engine/datasets/processor/qwen3_omni_moe_processor.py
+++ b/src/lmms_engine/datasets/processor/qwen3_omni_moe_processor.py
@@ -21,18 +21,12 @@ class Qwen3OmniMoeDataProcessor(BaseQwen2_5_DataProcessor):
         # Set image processor parameters
         image_max_pixels = self.config.extra_kwargs.get("image_max_pixels", None)
         image_min_pixels = self.config.extra_kwargs.get("image_min_pixels", None)
-        if image_max_pixels:
-            processor.image_processor.max_pixels = image_max_pixels
-        if image_min_pixels:
-            processor.image_processor.min_pixels = image_min_pixels
+        self._set_vision_processor_size(processor.image_processor, image_min_pixels, image_max_pixels)
 
         # Set video processor parameters
         video_max_pixels = self.config.extra_kwargs.get("video_max_pixels", None)
         video_min_pixels = self.config.extra_kwargs.get("video_min_pixels", None)
-        if video_max_pixels:
-            processor.video_processor.max_pixels = video_max_pixels
-        if video_min_pixels:
-            processor.video_processor.min_pixels = video_min_pixels
+        self._set_vision_processor_size(processor.video_processor, video_min_pixels, video_max_pixels)
 
         # Set audio processor parameters
         audio_max_length = self.config.extra_kwargs.get("audio_max_length", None)

--- a/src/lmms_engine/datasets/processor/qwen3_vl_processor.py
+++ b/src/lmms_engine/datasets/processor/qwen3_vl_processor.py
@@ -20,18 +20,12 @@ class Qwen3_VLDataProcessor(BaseQwen2_5_DataProcessor):
         # Set image processor parameters
         image_max_pixels = self.config.extra_kwargs.get("image_max_pixels", None)
         image_min_pixels = self.config.extra_kwargs.get("image_min_pixels", None)
-        if image_max_pixels:
-            processor.image_processor.max_pixels = image_max_pixels
-        if image_min_pixels:
-            processor.image_processor.min_pixels = image_min_pixels
+        self._set_vision_processor_size(processor.image_processor, image_min_pixels, image_max_pixels)
 
         # Set video processor parameters
         video_max_pixels = self.config.extra_kwargs.get("video_max_pixels", None)
         video_min_pixels = self.config.extra_kwargs.get("video_min_pixels", None)
-        if video_max_pixels:
-            processor.video_processor.max_pixels = video_max_pixels
-        if video_min_pixels:
-            processor.video_processor.min_pixels = video_min_pixels
+        self._set_vision_processor_size(processor.video_processor, video_min_pixels, video_max_pixels)
         return processor
 
     def process(


### PR DESCRIPTION
## Summary
- Update Qwen VL/Omni data processors to apply image/video pixel limits through processor `size.shortest_edge` and `size.longest_edge`
- Remove reliance on deprecated/non-effective `min_pixels` and `max_pixels` attributes on image/video processors
- Share the size override logic in the base Qwen processor

## Validation
- `python -m compileall src/lmms_engine/datasets/processor/base_qwen2_5_processor.py src/lmms_engine/datasets/processor/qwen3_vl_processor.py src/lmms_engine/datasets/processor/qwen2_5_vl_processor.py src/lmms_engine/datasets/processor/qwen2_5_omni_processor.py src/lmms_engine/datasets/processor/qwen3_omni_moe_processor.py`
- Verified Qwen3-VL processor `extra_kwargs` populate image/video `size` values locally

Fixes #128