### PR TITLE
refactor(packing): extract online packing strategies

### DIFF
--- a/src/lmms_engine/datasets/iterable/multimodal_iterable_dataset.py
+++ b/src/lmms_engine/datasets/iterable/multimodal_iterable_dataset.py
@@ -28,6 +28,7 @@ except ImportError:
     logger.info("Azure SDK not installed. Skipping import.")
 
 from lmms_engine.datasets.iterable.base_iterable_dataset import BaseIterableDataset
+from lmms_engine.datasets.packing import build_online_packer
 
 
 class MultiModalIterableDataset(BaseIterableDataset, MultiModalDataLoadingMixin):
@@ -167,9 +168,13 @@ class MultiModalIterableDataset(BaseIterableDataset, MultiModalDataLoadingMixin)
         if self.config.packing:
             # Reset index at the start of each iteration pass
             self.cur_idx = 0
-            buffer = []
-            buffer_length = 0
             packing_length = self.config.packing_length
+            packing_kwargs = self.config.extra_kwargs.get("packing_kwargs", {})
+            packer = build_online_packer(
+                self.config.packing_strategy or "next_fit",
+                packing_length,
+                **packing_kwargs,
+            )
 
             # Iterate through the dataset once per epoch
             while self.cur_idx < len(curr_data_list):
@@ -180,33 +185,24 @@ class MultiModalIterableDataset(BaseIterableDataset, MultiModalDataLoadingMixin)
                     logger.error(f"Error getting one sample: {e}, skip this sample")
                     self.cur_idx += 1
                     continue
-                input_ids = data_dict["input_ids"]
-                data_length = input_ids.shape[0]
+                data_length = data_dict["input_ids"].shape[0]
                 self.cur_idx += 1
 
                 # Drop overlong sample if filtering is enabled
                 if data_length > packing_length and self.config.filter_overlong:
                     continue
 
-                # If current sample cannot fit into current buffer, yield the buffer first
-                if buffer_length > 0 and buffer_length + data_length > packing_length:
-                    yield buffer
-                    buffer = []
-                    buffer_length = 0
-
-                # If the sample is still longer than packing_length (and not filtered),
-                # yield it as its own batch to avoid stalling
+                # Oversized samples bypass the packer: flush whatever is buffered
+                # first (to preserve ordering) and yield the sample on its own.
                 if data_length > packing_length:
+                    yield from packer.flush()
                     yield [data_dict]
                     continue
 
-                # Append to buffer
-                buffer.append(data_dict)
-                buffer_length += data_length
+                yield from packer.add(data_dict, data_length)
 
             # Flush remaining buffer
-            if len(buffer) > 0:
-                yield buffer
+            yield from packer.flush()
         else:
             self.cur_idx = 0
             while self.cur_idx < len(curr_data_list):

--- a/src/lmms_engine/datasets/packing/__init__.py
+++ b/src/lmms_engine/datasets/packing/__init__.py
@@ -1,0 +1,37 @@
+"""Packing strategies for grouping variable-length samples into fixed-budget packs.
+
+Currently implements the online (streaming) side only. Offline strategies used
+by map-style datasets will be migrated here later.
+"""
+
+from .base import OnlinePackingStrategy
+from .online import BalancedPacking, BestFitPacking, NextFitPacking
+
+_ONLINE_REGISTRY = {
+    "next_fit": NextFitPacking,
+    "best_fit": BestFitPacking,
+    "balanced": BalancedPacking,
+}
+
+
+def build_online_packer(strategy: str, packing_length: int, **kwargs) -> OnlinePackingStrategy:
+    """Construct an online packer by name.
+
+    Args:
+        strategy: Strategy name. One of ``"next_fit"``, ``"best_fit"``,
+            ``"balanced"``.
+        packing_length: Per-pack token budget.
+        **kwargs: Forwarded to the concrete strategy's constructor.
+    """
+    if strategy not in _ONLINE_REGISTRY:
+        raise ValueError(f"Unknown online packing strategy: {strategy!r}. " f"Available: {sorted(_ONLINE_REGISTRY)}")
+    return _ONLINE_REGISTRY[strategy](packing_length, **kwargs)
+
+
+__all__ = [
+    "OnlinePackingStrategy",
+    "NextFitPacking",
+    "BestFitPacking",
+    "BalancedPacking",
+    "build_online_packer",
+]

--- a/src/lmms_engine/datasets/packing/base.py
+++ b/src/lmms_engine/datasets/packing/base.py
@@ -1,0 +1,56 @@
+"""Base classes for packing strategies.
+
+Two flavors:
+- OfflinePackingStrategy: all sample lengths known up-front; returns index groups.
+- OnlinePackingStrategy: streaming; samples arrive one-by-one, packs are emitted
+  as soon as they are ready.
+
+Only the online side is implemented for now (RFC). Offline will be migrated
+later from `naive/multimodal_dataset.py`.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Iterator, List
+
+
+class OnlinePackingStrategy(ABC):
+    """Pack samples in a streaming fashion.
+
+    Typical usage from an iterable dataset::
+
+        packer = SomeOnlinePacker(packing_length)
+        for item, length in stream:
+            yield from packer.add(item, length)
+        yield from packer.flush()
+
+    Implementations are responsible for buffering and deciding when a pack is
+    "ready" to be emitted. Oversized samples (length > packing_length) are
+    expected to be handled by the caller before `add` is invoked.
+    """
+
+    def __init__(self, packing_length: int) -> None:
+        self.packing_length = packing_length
+
+    @abstractmethod
+    def add(self, item: Any, length: int) -> Iterator[List[Any]]:
+        """Add one sample.
+
+        Args:
+            item: The opaque sample object (e.g. a data dict). The packer never
+                inspects it; callers consume it back via the yielded packs.
+            length: The token length of `item`. Must satisfy
+                ``length <= self.packing_length``.
+
+        Yields:
+            Zero or more packed batches. Each batch is a list of `item`s whose
+            total length is ``<= self.packing_length``.
+        """
+
+    @abstractmethod
+    def flush(self) -> Iterator[List[Any]]:
+        """Yield any remaining buffered items as final packs.
+
+        Should be called exactly once when the input stream is exhausted.
+        After `flush`, the packer's internal state is reset so the instance
+        can be reused for a new stream.
+        """

--- a/src/lmms_engine/datasets/packing/online.py
+++ b/src/lmms_engine/datasets/packing/online.py
@@ -1,0 +1,265 @@
+"""Online (streaming) packing strategies."""
+
+from typing import Any, Iterator, List, Tuple
+
+from .base import OnlinePackingStrategy
+
+
+class NextFitPacking(OnlinePackingStrategy):
+    """Single-buffer next-fit packing.
+
+    Behaviorally equivalent to the original logic in
+    ``MultiModalIterableDataset.__iter__``: maintain one open buffer; whenever
+    the next sample doesn't fit, flush the buffer and start a new one with
+    that sample.
+
+    This is the simplest online strategy and serves as a baseline. It does not
+    look ahead and tends to leave tail space unused.
+    """
+
+    def __init__(self, packing_length: int) -> None:
+        super().__init__(packing_length)
+        self._buffer: List[Any] = []
+        self._buffer_length: int = 0
+
+    def add(self, item: Any, length: int) -> Iterator[List[Any]]:
+        # If adding this sample would overflow, flush the current buffer first.
+        if self._buffer_length > 0 and self._buffer_length + length > self.packing_length:
+            yield self._buffer
+            self._buffer = []
+            self._buffer_length = 0
+
+        self._buffer.append(item)
+        self._buffer_length += length
+
+    def flush(self) -> Iterator[List[Any]]:
+        if self._buffer:
+            yield self._buffer
+        self._buffer = []
+        self._buffer_length = 0
+
+
+class BestFitPacking(OnlinePackingStrategy):
+    """K-bucket best-fit packing.
+
+    Maintains up to ``num_open_buckets`` open packs. Each incoming sample is
+    placed into the bucket whose remaining capacity is the smallest one that
+    can still accommodate it. A bucket is emitted when it crosses
+    ``fill_threshold * packing_length``; if no bucket can fit the sample and
+    we already have ``num_open_buckets`` open, the fullest bucket is evicted
+    to make room.
+
+    This significantly reduces tail waste compared to next-fit by allowing
+    multiple in-flight packs at once.
+    """
+
+    def __init__(
+        self,
+        packing_length: int,
+        num_open_buckets: int = 4,
+        fill_threshold: float = 0.95,
+    ) -> None:
+        super().__init__(packing_length)
+        if num_open_buckets < 1:
+            raise ValueError("num_open_buckets must be >= 1")
+        if not 0.0 < fill_threshold <= 1.0:
+            raise ValueError("fill_threshold must be in (0, 1]")
+        self.num_open_buckets = num_open_buckets
+        self.fill_full = int(packing_length * fill_threshold)
+        # Each bucket is [length, items].
+        self._buckets: List[List[Any]] = []
+
+    def _find_best_bucket(self, length: int) -> int:
+        """Return the index of the bucket with the smallest remaining space
+        that can still fit ``length``, or -1 if none can."""
+        best_idx = -1
+        best_remain = self.packing_length + 1
+        for i, (blen, _) in enumerate(self._buckets):
+            remain = self.packing_length - blen - length
+            if 0 <= remain < best_remain:
+                best_remain = remain
+                best_idx = i
+        return best_idx
+
+    def add(self, item: Any, length: int) -> Iterator[List[Any]]:
+        idx = self._find_best_bucket(length)
+
+        if idx == -1:
+            # Nothing can fit this sample.
+            if len(self._buckets) < self.num_open_buckets:
+                self._buckets.append([length, [item]])
+            else:
+                # Evict the fullest bucket to make room.
+                evict_idx = max(range(len(self._buckets)), key=lambda i: self._buckets[i][0])
+                yield self._buckets[evict_idx][1]
+                self._buckets[evict_idx] = [length, [item]]
+            return
+
+        self._buckets[idx][0] += length
+        self._buckets[idx][1].append(item)
+
+        # Emit early if the bucket is "full enough" -- no point keeping it open.
+        if self._buckets[idx][0] >= self.fill_full:
+            yield self._buckets.pop(idx)[1]
+
+    def flush(self) -> Iterator[List[Any]]:
+        for blen, items in self._buckets:
+            if items:
+                yield items
+        self._buckets = []
+
+
+class BalancedPacking(OnlinePackingStrategy):
+    """Two-phase pack-then-balance.
+
+    Phase 1 (online): use best-fit to fill ``balance_window`` packs.
+    Phase 2 (batched): run swap-based local search to minimize the
+    length variance across those packs.
+    Phase 3: yield all balanced packs in one batch.
+
+    Trades a small amount of latency (one window's worth of samples) for
+    significantly more uniform pack lengths -- which directly translates
+    to better DP utilization since each step's wall time is bounded by
+    the slowest rank's token count.
+
+    Note: pack ordering is not preserved within a window. Samples within a
+    window may be reshuffled across packs by the balancing step.
+    """
+
+    def __init__(
+        self,
+        packing_length: int,
+        balance_window: int = 64,
+        num_open_buckets: int = 8,
+        max_swap_iters: int = 200,
+        min_gain: int = 1,
+    ) -> None:
+        super().__init__(packing_length)
+        if balance_window < 1:
+            raise ValueError("balance_window must be >= 1")
+        if num_open_buckets < 1:
+            raise ValueError("num_open_buckets must be >= 1")
+        self.balance_window = balance_window
+        self.num_open_buckets = num_open_buckets
+        self.max_swap_iters = max_swap_iters
+        self.min_gain = min_gain
+
+        # Open buckets being filled. Each bucket = [length, [(item, length), ...]].
+        # We carry per-item lengths because the balance phase needs them.
+        self._open: List[List[Any]] = []
+        # Completed packs awaiting balancing. Same shape as buckets.
+        self._completed: List[List[Any]] = []
+
+    # ---- Phase 1: best-fit fill -----------------------------------------
+    def add(self, item: Any, length: int) -> Iterator[List[Any]]:
+        n = self.packing_length
+
+        # Find best-fit open bucket.
+        best_idx = -1
+        best_remain = n + 1
+        for i, (blen, _) in enumerate(self._open):
+            remain = n - blen - length
+            if 0 <= remain < best_remain:
+                best_remain = remain
+                best_idx = i
+
+        if best_idx == -1:
+            if len(self._open) < self.num_open_buckets:
+                self._open.append([length, [(item, length)]])
+            else:
+                # All slots taken; evict the fullest into _completed.
+                evict_idx = max(range(len(self._open)), key=lambda i: self._open[i][0])
+                self._completed.append(self._open[evict_idx])
+                self._open[evict_idx] = [length, [(item, length)]]
+        else:
+            self._open[best_idx][0] += length
+            self._open[best_idx][1].append((item, length))
+
+        if len(self._completed) >= self.balance_window:
+            yield from self._balance_and_emit()
+
+    def flush(self) -> Iterator[List[Any]]:
+        # Move all still-open buckets into completed, then balance & emit.
+        for blen, pairs in self._open:
+            if pairs:
+                self._completed.append([blen, pairs])
+        self._open = []
+        if self._completed:
+            yield from self._balance_and_emit()
+
+    # ---- Phase 2 + 3: balance and yield ---------------------------------
+    def _balance_and_emit(self) -> Iterator[List[Any]]:
+        sums: List[int] = [c[0] for c in self._completed]
+        packs: List[List[Tuple[Any, int]]] = [c[1] for c in self._completed]
+        self._completed = []
+
+        if len(packs) >= 2:
+            self._balance(packs, sums)
+
+        for pairs in packs:
+            if pairs:
+                yield [item for item, _ in pairs]
+
+    def _balance(
+        self,
+        packs: List[List[Tuple[Any, int]]],
+        sums: List[int],
+    ) -> None:
+        """Swap-based local search to reduce length variance.
+
+        Each iteration picks the (max, min) pair and tries:
+        1. A one-way move from max -> min that strictly shrinks the gap.
+        2. A swap (item from max <-> item from min) that strictly shrinks
+           the gap by more than ``min_gain``.
+        Stops when no improvement is possible or after ``max_swap_iters``.
+        """
+        n = self.packing_length
+
+        for _ in range(self.max_swap_iters):
+            hi = max(range(len(sums)), key=lambda i: sums[i])
+            lo = min(range(len(sums)), key=lambda i: sums[i])
+            gap = sums[hi] - sums[lo]
+            if gap <= self.min_gain:
+                break
+
+            # Try a one-way move first.
+            best_move_idx = -1
+            best_new_gap = gap
+            for idx, (_, ilen) in enumerate(packs[hi]):
+                if sums[lo] + ilen > n:
+                    continue
+                new_gap = abs((sums[hi] - ilen) - (sums[lo] + ilen))
+                if new_gap < best_new_gap:
+                    best_new_gap = new_gap
+                    best_move_idx = idx
+
+            if best_move_idx >= 0:
+                item, ilen = packs[hi].pop(best_move_idx)
+                packs[lo].append((item, ilen))
+                sums[hi] -= ilen
+                sums[lo] += ilen
+                continue
+
+            # Fall back to a swap.
+            best_swap = None
+            best_new_gap = gap
+            for i, (_, a) in enumerate(packs[hi]):
+                for j, (_, b) in enumerate(packs[lo]):
+                    if a <= b:
+                        continue
+                    new_hi = sums[hi] - a + b
+                    new_lo = sums[lo] - b + a
+                    if new_hi > n or new_lo > n:
+                        continue
+                    new_gap = abs(new_hi - new_lo)
+                    if new_gap + self.min_gain < gap and new_gap < best_new_gap:
+                        best_new_gap = new_gap
+                        best_swap = (i, j)
+
+            if best_swap is None:
+                break
+
+            i, j = best_swap
+            packs[hi][i], packs[lo][j] = packs[lo][j], packs[hi][i]
+            sums[hi] = sum(l for _, l in packs[hi])
+            sums[lo] = sum(l for _, l in packs[lo])


### PR DESCRIPTION
## Summary

Refactors the inline next-fit packing logic in `MultiModalIterableDataset`
into a dedicated `datasets/packing/` module, and adds two new strategies for
better DP utilization on packed multimodal training.

## Strategies

- **`next_fit`** — single-buffer next-fit. Behaviorally identical to the
  previous inline logic; default for backward compatibility.
- **`best_fit`** — K-bucket best-fit. Maintains multiple open packs and
  places each sample in the bucket with the smallest sufficient remainder.
  Significantly reduces tail waste vs. next-fit.
- **`balanced`** — two-phase pack-then-balance. Phase 1 fills `balance_window`
  packs via best-fit; phase 2 runs swap-based local search to minimize
  length variance across that window. Trades a small amount of latency
  (one window of buffering) for uniform pack lengths, which directly
  translates to better DP step time since each step is bounded by the
  slowest rank.

## Config

```yaml
dataset_config:
  packing: true
  packing_strategy: balanced     # next_fit | best_fit | balanced
  packing_length: 40960
  extra_kwargs:
    packing_kwargs:              # forwarded to the packer's __init__
      balance_window: 32
      num_open_buckets: 8
```

`packing_strategy` defaults to `next_fit` if not set, so existing configs
behave identically.

## Files

- `src/lmms_engine/datasets/packing/base.py` — `OnlinePackingStrategy` ABC
- `src/lmms_engine/datasets/packing/online.py` — three concrete strategies
- `src/lmms_engine/datasets/packing/__init__.py` — `build_online_packer` factory
- `src/lmms_engine/datasets/iterable/multimodal_iterable_dataset.py` —
  swap inline packing for the new packer

## Notes

- Offline packing (used by `naive/multimodal_dataset.py`) is intentionally
  out of scope here; will be migrated in a follow-up.
- Behavioral equivalence of the new `next_fit` vs. the original inline
  logic was verified locally with 50 randomized trials.