### PR TITLE
feat(kernels): pluggable varlen attention backend (FA2 / SDPA)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,60 +2,123 @@
 
 ## Repository Overview
 
-**LMMs Engine** is a training framework for Large Multimodal Models (LMMs) developed by LMMs-Lab. This is a Python package focused on highly efficient training of multimodal models with support for various architectures and training paradigms.
+**LMMs Engine** is a training framework for Large Multimodal Models (LMMs) developed by LMMs-Lab. It is a Python package focused on highly efficient training of multimodal models with support for various architectures and training paradigms (FSDP2, sequence parallelism, expert parallelism, etc.).
 
 ## Configuration System
 
-Training is configured via YAML files. YAML is recommended for better readability and comment support.
+Training is configured via Hydra (`hydra-core` + `omegaconf`). The default config lives at `src/lmms_engine/launch/config/default_config.yaml`. Users typically:
 
-### YAML Configuration (Recommended)
+1. Write a YAML config (see `examples/`) and pass it via `config_yaml=...`, **or**
+2. Override individual fields directly on the command line via Hydra dotted-path syntax.
+
+The top-level schema (flat, no list wrapper) is:
 
 ```yaml
-# Configuration supports comments in YAML
-- type: trainer
-  config:
-    trainer_type: hf_trainer
-    dataset_config:
-      # Dataset configuration
-      dataset_name: "example_dataset"
-    model_config:
-      # Model configuration  
-      model_name: "example_model"
-    # TrainingArguments parameters
-    output_dir: "./output"
-    num_train_epochs: 3
+trainer_type: fsdp2_trainer        # e.g. fsdp2_trainer, hf_trainer
+dataset_config:                    # -> DatasetConfig
+  dataset_type: qwen3_vl_iterable
+  dataset_format: yaml
+  dataset_path: data/debug.yaml
+  processor_config:
+    processor_name: Qwen/Qwen3-VL-8B-Instruct
+    processor_type: qwen3_vl
+  packing: true
+  packing_length: 32000
+model_config:                      # -> ModelConfig
+  load_from_pretrained_path: Qwen/Qwen3-VL-8B-Instruct
+  attn_implementation: flash_attention_2   # or "sdpa"
+trainer_args:                      # -> TrainingArguments (HF + lmms-engine extras)
+  output_dir: ./output/run
+  per_device_train_batch_size: 1
+  learning_rate: 2.0e-04
+  num_train_epochs: 1
+  bf16: true
+  fsdp2: true
+  use_rmpad: true
+  sp_ulysses_degree: 1
+  ep_degree: 1
 ```
+
+See `examples/qwen3_vl/example_config.yaml`, `examples/qwen3_vl_moe/qwen3_vl_moe_ep8.yaml`, etc. for full templates.
 
 ## Development Commands
 
-### Training Launch
+### Training Launch (Hydra override is recommended)
+
+Prefer **option 1 (pure Hydra override)** or **option 2 (file + override)**. Loading a YAML file alone is supported but discouraged — overriding individual fields on the command line is more reproducible and composes better with sweeps.
 
 ```bash
-# Recommended: torchrun with YAML config
-torchrun --nproc_per_node=8 --nnodes=1 --node_rank=0 \
-  --master_addr="127.0.0.1" --master_port="8000" \
-  -m lmms_engine.launch.cli config_yaml=path/to/config.yaml
-
-# Hydra overrides (no config file needed)
-torchrun --nproc_per_node=8 --nnodes=1 --node_rank=0 \
-  --master_addr="127.0.0.1" --master_port="8000" \
-  -m lmms_engine.launch.cli \
+# 1) Hydra override only (recommended; defaults from default_config.yaml)
+torchrun --nproc_per_node=8 -m lmms_engine.launch.cli \
   trainer_type=fsdp2_trainer \
-  model_config.load_from_pretrained_path="model/path" \
-  trainer_args.output_dir="./output" \
-  trainer_args.num_train_epochs=3
+  model_config.load_from_pretrained_path=Qwen/Qwen3-VL-8B-Instruct \
+  model_config.attn_implementation=flash_attention_2 \
+  trainer_args.output_dir=./output/debug \
+  trainer_args.bf16=true \
+  trainer_args.fsdp2=true \
+  trainer_args.use_rmpad=true
+
+# 2) Load a config file, then override individual fields (recommended)
+torchrun --nproc_per_node=8 -m lmms_engine.launch.cli \
+  --config-path examples/qwen3_vl \
+  --config-name example_config \
+  trainer_args.learning_rate=1.0e-05 \
+  trainer_args.output_dir=./output/sweep_lr1e5
+
+# 3) Pure YAML config (works, but no per-run overrides)
+torchrun --nproc_per_node=8 --nnodes=1 --node_rank=0 \
+  --master_addr=127.0.0.1 --master_port=8000 \
+  -m lmms_engine.launch.cli \
+  --config-path examples/qwen3_vl \
+  --config-name example_config
 ```
+
+Hydra dotted paths map directly to YAML nesting (`trainer_args.fsdp_config.reshard_after_forward=true`). `--config-path` takes a directory (absolute or relative to CWD), `--config-name` is the YAML basename without extension.
+
+There is also a legacy `config_yaml=path/to/config.yaml` field that loads a YAML and merges it on top of the defaults — it still works, but `--config-path` / `--config-name` is the preferred Hydra-native way.
+
+### Checkpoint Merging
+
+FSDP2 saves sharded checkpoints; merge them into a single HF-compatible checkpoint with `lmms_engine.merger`:
+
+```bash
+# Merge a regular checkpoint
+python -m lmms_engine.merger --checkpoint_path ./output/run/checkpoint-1000
+
+# Merge EMA weights
+python -m lmms_engine.merger \
+  --checkpoint_path ./output/run/checkpoint-1000 \
+  --checkpoint_type ema \
+  --output_path ./output/run/checkpoint-1000-ema-merged
+```
+
+Implementation: `src/lmms_engine/merger/` — `base.CheckpointMerger` (ABC) + `fsdp2.FSDP2Merger`. Pass a parent dir and the latest `checkpoint-*` is auto-detected.
 
 ### Development Setup
 
 ```bash
-# Install with development dependencies
-uv pip install -e ".[all]"  # Includes preference learning and storage
-
-# Performance optimizations
-uv pip install flash-attn --no-build-isolation
+uv pip install -e ".[all]"
+uv pip install flash-attn --no-build-isolation   # CUDA only
 uv pip install liger-kernel
 ```
+
+## Attention Backend
+
+Use `lmms_engine.kernels.attention.varlen_attn` in new model `*_ops.py` files instead of importing `flash_attn` directly. It dispatches to either FA2 or PyTorch SDPA based on the HF config:
+
+```python
+from lmms_engine.kernels.attention import varlen_attn
+
+attn_output = varlen_attn(
+    q=query_states, k=key_states, v=value_states,
+    cu_seqlens_q=cu_seq_lens, cu_seqlens_k=cu_seq_lens,
+    max_seqlen_q=max_seqlen, max_seqlen_k=max_seqlen,
+    causal=True, softmax_scale=self.head_dim**-0.5,
+    backend=self.config._attn_implementation,   # "flash_attention_2" | "sdpa"
+)
+```
+
+Backend keys match HF `_attn_implementation` strings, so no translation layer is needed. This keeps the codebase portable to environments without flash-attn (e.g. ROCm without the ROCm fork installed). Existing reference implementations: `src/lmms_engine/models/qwen3/qwen3_ops.py`, `qwen3_vl/qwen3_vl_ops.py`, `qwen3_vl_moe/qwen3_vl_moe_ops.py`.
 
 ## Development Philosophy
 
@@ -77,10 +140,8 @@ uv pip install liger-kernel
 - **Minimal Changes**: Only modify code related to the task at hand
 - **Function Ordering**: Define composing functions before their components
 - **TODO Comments**: Mark issues in existing code with "TODO:" prefix
-- **Simplicity**: Prioritize simplicity and readability over clever solutions
-- **Build Iteratively** Start with minimal functionality and verify it works before adding complexity
+- **Build Iteratively**: Start with minimal functionality and verify it works before adding complexity
 - **Run Tests**: Test your code frequently with realistic inputs and validate outputs
 - **Build Test Environments**: Create testing environments for components that are difficult to validate directly
-- **Functional Code**: Use functional and stateless approaches where they improve clarity
-- **Clean logic**: Keep core logic clean and push implementation details to the edges
-- **File Organsiation**: Balance file organization with simplicity - use an appropriate number of files for the project scale
+- **Clean Logic**: Keep core logic clean and push implementation details to the edges
+- **File Organisation**: Balance file organization with simplicity — use an appropriate number of files for the project scale

--- a/src/lmms_engine/kernels/attention.py
+++ b/src/lmms_engine/kernels/attention.py
@@ -1,0 +1,185 @@
+"""Attention backends.
+
+Varlen attention implementations with identical signatures, dispatched via
+``varlen_attn(..., backend=...)``.
+"""
+
+from typing import Tuple
+
+import torch
+import torch.nn.functional as F
+
+from lmms_engine.utils.import_utils import is_flash_attn_2_available
+
+if is_flash_attn_2_available():
+    from flash_attn import flash_attn_varlen_func
+else:
+    flash_attn_varlen_func = None
+
+
+def fa2_varlen_attn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size: Tuple[int, int] = (-1, -1),
+    dropout_p: float = 0.0,
+) -> torch.Tensor:
+    """FlashAttention-2 varlen forward.
+
+    Inputs ``q``, ``k``, ``v`` have shape ``(total_tokens, num_heads, head_dim)``.
+    Returns a tensor of the same shape as ``q``.
+    """
+    assert flash_attn_varlen_func is not None, "flash_attn is not installed; use backend='sdpa' or install flash-attn."
+    return flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        window_size=window_size,
+        dropout_p=dropout_p,
+    )
+
+
+def sdpa_varlen_attn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size: Tuple[int, int] = (-1, -1),
+    dropout_p: float = 0.0,
+) -> torch.Tensor:
+    """SDPA-based varlen attention with the same signature as ``fa2_varlen_attn``.
+
+    Builds a block-diagonal additive mask from ``cu_seqlens`` and dispatches to
+    ``torch.nn.functional.scaled_dot_product_attention``. Intended as a portable
+    fallback (e.g. ROCm without flash-attn). Memory cost is O((sum_q)*(sum_k));
+    for very long packed sequences prefer the FA2 backend.
+
+    Inputs ``q``, ``k``, ``v`` have shape ``(total_tokens, num_heads, head_dim)``.
+    """
+    total_q, num_heads_q, head_dim = q.shape
+    total_k, num_heads_k, _ = k.shape
+
+    # GQA: broadcast kv heads to query heads
+    if num_heads_k != num_heads_q:
+        assert (
+            num_heads_q % num_heads_k == 0
+        ), f"num_heads_q ({num_heads_q}) must be divisible by num_heads_k ({num_heads_k})"
+        repeat = num_heads_q // num_heads_k
+        k = k.repeat_interleave(repeat, dim=1)
+        v = v.repeat_interleave(repeat, dim=1)
+
+    # (T, H, D) -> (1, H, T, D) for SDPA
+    q_ = q.transpose(0, 1).unsqueeze(0)
+    k_ = k.transpose(0, 1).unsqueeze(0)
+    v_ = v.transpose(0, 1).unsqueeze(0)
+
+    # Build additive block-diagonal mask of shape (total_q, total_k).
+    # Position-based construction avoids Python loops over sequences.
+    device = q.device
+    q_seq_id = torch.zeros(total_q, dtype=torch.long, device=device)
+    q_seq_id[cu_seqlens_q[1:-1].long()] = 1
+    q_seq_id = q_seq_id.cumsum(0)  # which sequence each query token belongs to
+
+    k_seq_id = torch.zeros(total_k, dtype=torch.long, device=device)
+    k_seq_id[cu_seqlens_k[1:-1].long()] = 1
+    k_seq_id = k_seq_id.cumsum(0)
+
+    # Same-sequence mask: True where attention is allowed (before causal/window).
+    allow = q_seq_id.unsqueeze(1) == k_seq_id.unsqueeze(0)  # (Tq, Tk)
+
+    if causal or window_size != (-1, -1):
+        # Per-sequence local positions
+        q_starts = cu_seqlens_q[q_seq_id]
+        k_starts = cu_seqlens_k[k_seq_id]
+        q_pos = (torch.arange(total_q, device=device) - q_starts).unsqueeze(1)  # (Tq, 1)
+        k_pos = (torch.arange(total_k, device=device) - k_starts).unsqueeze(0)  # (1, Tk)
+
+        if causal:
+            # FA2 convention: align q to the END of k when lengths differ.
+            offset = max_seqlen_k - max_seqlen_q
+            allow &= k_pos <= (q_pos + offset)
+
+        left, right = window_size
+        if left >= 0:
+            allow &= k_pos >= (q_pos - left)
+        if right >= 0:
+            allow &= k_pos <= (q_pos + right)
+
+    attn_mask = torch.zeros(total_q, total_k, dtype=q.dtype, device=device)
+    attn_mask.masked_fill_(~allow, float("-inf"))
+    attn_mask = attn_mask.unsqueeze(0).unsqueeze(0)  # (1, 1, Tq, Tk)
+
+    out = F.scaled_dot_product_attention(
+        q_,
+        k_,
+        v_,
+        attn_mask=attn_mask,
+        dropout_p=dropout_p,
+        scale=softmax_scale,
+        is_causal=False,  # causal already encoded in mask
+    )
+    # (1, H, Tq, D) -> (Tq, H, D)
+    return out.squeeze(0).transpose(0, 1).contiguous()
+
+
+_BACKENDS = {
+    "flash_attention_2": fa2_varlen_attn,
+    "sdpa": sdpa_varlen_attn,
+}
+
+
+def varlen_attn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    causal: bool = False,
+    softmax_scale: float | None = None,
+    window_size: Tuple[int, int] = (-1, -1),
+    dropout_p: float = 0.0,
+    backend: str = "flash_attention_2",
+) -> torch.Tensor:
+    """Dispatch varlen attention to the requested backend.
+
+    Args:
+        backend: ``"flash_attention_2"`` or ``"sdpa"`` (matches HF
+            ``config._attn_implementation`` values).
+    """
+    if backend not in _BACKENDS:
+        raise ValueError(f"Unknown attention backend: {backend!r}. Available: {list(_BACKENDS)}")
+    return _BACKENDS[backend](
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        window_size=window_size,
+        dropout_p=dropout_p,
+    )
+
+
+__all__ = ["fa2_varlen_attn", "sdpa_varlen_attn", "varlen_attn"]

--- a/src/lmms_engine/models/qwen3/qwen3_ops.py
+++ b/src/lmms_engine/models/qwen3/qwen3_ops.py
@@ -42,13 +42,15 @@ logger = logging.get_logger(__name__)
 
 
 if is_flash_attn_2_available():
-    from flash_attn import flash_attn_func, flash_attn_varlen_func
+    from flash_attn import flash_attn_func
     from flash_attn.bert_padding import (
         index_first_axis,
         pad_input,
         rearrange,
         unpad_input,
     )
+
+from lmms_engine.kernels.attention import varlen_attn
 
 try:
     from flash_attn.layers.rotary import apply_rotary_emb_func
@@ -278,7 +280,8 @@ def attn_forward(
 
     max_seqlen = torch.diff(cu_seq_lens).max().item() if cu_seq_lens is not None else None
     window_size = (-1, -1)
-    attn_output = flash_attn_varlen_func(
+
+    attn_output = varlen_attn(
         q=query_states,
         k=key_states,
         v=value_states,
@@ -290,6 +293,7 @@ def attn_forward(
         window_size=window_size,
         softmax_scale=self.head_dim**-0.5,
         dropout_p=0.0,
+        backend=self.config._attn_implementation,
     )
 
     ########## AlltoAll for Ulysses ##########

--- a/src/lmms_engine/models/qwen3_vl/qwen3_vl_ops.py
+++ b/src/lmms_engine/models/qwen3_vl/qwen3_vl_ops.py
@@ -35,8 +35,9 @@ from ..common_ops.rope import qwen3_vl_get_rope_index
 from ..sequence_packing_utils import _unpad_input
 
 if is_flash_attn_2_available():
-    from flash_attn import flash_attn_func, flash_attn_varlen_func
     from flash_attn.bert_padding import index_first_axis, rearrange
+
+from lmms_engine.kernels.attention import varlen_attn
 
 from ..common_ops.visual import (
     parse_visual_output_with_deepstack as parse_visual_output,
@@ -563,7 +564,7 @@ def attn_forward(
 
     window_size = (-1, -1)
 
-    attn_output = flash_attn_varlen_func(
+    attn_output = varlen_attn(
         q=query_states,
         k=key_states,
         v=value_states,
@@ -575,6 +576,7 @@ def attn_forward(
         window_size=window_size,
         softmax_scale=self.head_dim**-0.5,
         dropout_p=0.0,
+        backend=self.config._attn_implementation,
     )
 
     ########## AlltoAll for Ulysses ##########

--- a/src/lmms_engine/models/qwen3_vl_moe/qwen3_vl_moe_ops.py
+++ b/src/lmms_engine/models/qwen3_vl_moe/qwen3_vl_moe_ops.py
@@ -40,7 +40,7 @@ from ..sequence_packing_utils import BaseModelOutputWithPastAndRmpad, _unpad_inp
 
 if is_flash_attn_2_available():
     try:
-        from flash_attn import flash_attn_func, flash_attn_varlen_func
+        from flash_attn import flash_attn_func
         from flash_attn.bert_padding import (
             index_first_axis,
             pad_input,
@@ -52,6 +52,7 @@ if is_flash_attn_2_available():
     except:
         raise ModuleNotFoundError("flash_attn is not available. Please install it via `pip install flash_attn`.")
 
+from lmms_engine.kernels.attention import varlen_attn
 
 from ..common_ops.visual import (
     parse_visual_output_with_deepstack as parse_visual_output,
@@ -545,7 +546,7 @@ def attn_forward(
 
     window_size = (-1, -1)
 
-    attn_output = flash_attn_varlen_func(
+    attn_output = varlen_attn(
         q=query_states,
         k=key_states,
         v=value_states,
@@ -557,6 +558,7 @@ def attn_forward(
         window_size=window_size,
         softmax_scale=head_dim**-0.5,
         dropout_p=0.0,
+        backend=self.config._attn_implementation,
     )
 
     if ulysses_sp_size > 1:


### PR DESCRIPTION
## Summary

- Introduce `lmms_engine.kernels.attention.varlen_attn`, a thin dispatcher that selects between FlashAttention-2 and PyTorch SDPA based on a backend key. Backend keys (`flash_attention_2`, `sdpa`) match HF's `config._attn_implementation` so call sites need no translation layer.
- Switch `qwen3`, `qwen3_vl`, and `qwen3_vl_moe` ops to call `varlen_attn(..., backend=self.config._attn_implementation)` instead of importing `flash_attn_varlen_func` directly.
- Rewrite `CLAUDE.md` to reflect the current Hydra-based config system, document the FSDP2 merger CLI, and recommend `varlen_attn` for new model implementations.

## Why

Several environments (notably ROCm on MI200) cannot install the upstream pypi `flash-attn` package. Today every `*_ops.py` file does `from flash_attn import flash_attn_varlen_func` at import time, hard-blocking those environments even when SDPA would suffice. Centralizing the call through `varlen_attn` lets us pick the backend per attention call from the existing HF config flag, with zero behavior change when FA2 is available.

## What's in this PR

**New module**

- `src/lmms_engine/kernels/attention.py`
  - `fa2_varlen_attn` — thin wrapper over `flash_attn_varlen_func`
  - `sdpa_varlen_attn` — same signature; builds a block-diagonal mask from `cu_seqlens` (handles GQA via `repeat_interleave`, FA2-style causal alignment to the end of `k`, and `window_size`) and dispatches to `F.scaled_dot_product_attention`
  - `varlen_attn(..., backend=...)` — top-level dispatcher; backend dict `{"flash_attention_2": fa2, "sdpa": sdpa}`

**Call site updates**

- `src/lmms_engine/models/qwen3/qwen3_ops.py`
- `src/lmms_engine/models/qwen3_vl/qwen3_vl_ops.py`
- `src/lmms_engine/models/qwen3_vl_moe/qwen3_vl_moe_ops.py`

Each replaces its direct `flash_attn_varlen_func(...)` call with:

```python
attn_output = varlen_attn(
    q=..., k=..., v=...,
    cu_seqlens_q=..., cu_seqlens_k=...,
    max_seqlen_q=..., max_seqlen_k=...,
    causal=True, softmax_scale=...,
    backend=self.config._attn_implementation,
)
```

Other models still import `flash_attn` directly; they can be migrated incrementally.

## Docs

- `CLAUDE.md` rewritten:
  - flat top-level config schema (no more `- type: trainer` list)
  - Hydra `--config-path` / `--config-name` recommended over the legacy `config_yaml=...` field
  - new sections for the checkpoint merger CLI and the `varlen_attn` helper

## Validation

- Import smoke test: `varlen_attn` and the three updated `attn_forward`s import cleanly.
- Numerical/runtime correctness on FA2 path: verified by user (no behavior change vs. the previous direct call).
- SDPA backend: not exercised in CI yet; activated by setting `model_config.attn_implementation=sdpa`.

## Out of scope

- Migrating the remaining `*_ops.py` files (qwen2_audio, qwen2_5_omni, qwen3_omni_moe, llava_onevision1_5, etc.).
- Decoupling `rmpad` / `liger` patches.
- Adding ROCm install docs / CI.