### PR TITLE
fix(packing): rename next_fit to first_fit

### DIFF
--- a/src/lmms_engine/datasets/iterable/multimodal_iterable_dataset.py
+++ b/src/lmms_engine/datasets/iterable/multimodal_iterable_dataset.py
@@ -171,7 +171,7 @@ class MultiModalIterableDataset(BaseIterableDataset, MultiModalDataLoadingMixin)
             packing_length = self.config.packing_length
             packing_kwargs = self.config.extra_kwargs.get("packing_kwargs", {})
             packer = build_online_packer(
-                self.config.packing_strategy or "next_fit",
+                self.config.packing_strategy or "first_fit",
                 packing_length,
                 **packing_kwargs,
             )

--- a/src/lmms_engine/datasets/packing/__init__.py
+++ b/src/lmms_engine/datasets/packing/__init__.py
@@ -5,10 +5,10 @@ by map-style datasets will be migrated here later.
 """
 
 from .base import OnlinePackingStrategy
-from .online import BalancedPacking, BestFitPacking, NextFitPacking
+from .online import BalancedPacking, BestFitPacking, FirstFitPacking
 
 _ONLINE_REGISTRY = {
-    "next_fit": NextFitPacking,
+    "first_fit": FirstFitPacking,
     "best_fit": BestFitPacking,
     "balanced": BalancedPacking,
 }
@@ -18,7 +18,7 @@ def build_online_packer(strategy: str, packing_length: int, **kwargs) -> OnlineP
     """Construct an online packer by name.
 
     Args:
-        strategy: Strategy name. One of ``"next_fit"``, ``"best_fit"``,
+        strategy: Strategy name. One of ``"first_fit"``, ``"best_fit"``,
             ``"balanced"``.
         packing_length: Per-pack token budget.
         **kwargs: Forwarded to the concrete strategy's constructor.
@@ -30,7 +30,7 @@ def build_online_packer(strategy: str, packing_length: int, **kwargs) -> OnlineP
 
 __all__ = [
     "OnlinePackingStrategy",
-    "NextFitPacking",
+    "FirstFitPacking",
     "BestFitPacking",
     "BalancedPacking",
     "build_online_packer",

--- a/src/lmms_engine/datasets/packing/online.py
+++ b/src/lmms_engine/datasets/packing/online.py
@@ -5,8 +5,8 @@ from typing import Any, Iterator, List, Tuple
 from .base import OnlinePackingStrategy
 
 
-class NextFitPacking(OnlinePackingStrategy):
-    """Single-buffer next-fit packing.
+class FirstFitPacking(OnlinePackingStrategy):
+    """Single-buffer first-fit packing.
 
     Behaviorally equivalent to the original logic in
     ``MultiModalIterableDataset.__iter__``: maintain one open buffer; whenever


### PR DESCRIPTION
## Summary

Existing yaml configs use ``packing_strategy: first_fit`` (which is also the
name still used by the naive offline datasets). PR #161 introduced an online
packer registry under the textbook name ``next_fit``, which raises
``ValueError`` on every config that wasn't updated -- breaking iterable
dataset training configs in the wild.

Rename ``NextFitPacking`` to ``FirstFitPacking`` and update the registry key
to ``first_fit``. Also update the iterable dataset's default fallback.

The algorithm is unchanged.