### PR TITLE
feat(datasets): support optional video_start/video_end on video_url

### DIFF
--- a/src/lmms_engine/datasets/iterable/qwen3_vl_iterable_dataset.py
+++ b/src/lmms_engine/datasets/iterable/qwen3_vl_iterable_dataset.py
@@ -32,10 +32,13 @@ class Qwen3VLIterableDataset(VisionSFTIterableDataset):
                     images_list.append(content["image_url"]["url"])
                 elif content["type"] == "video_url":
                     # Loading videos with fps
+                    video_url = content["video_url"]
+                    extra = {k: v for k, v in video_url.items() if k != "url" and v is not None}
                     frames, video_metadata, sample_fps = self.load_videos(
-                        content["video_url"]["url"],
+                        video_url["url"],
                         data_folder=data_folder,
                         fps=self.config.fps,
+                        video_kwargs=extra or None,
                     )
                     videos.append(frames)
                     # Update kwargs
@@ -55,19 +58,20 @@ class Qwen3VLIterableDataset(VisionSFTIterableDataset):
         inputs = self.processor.process(images=images, hf_messages=hf_messages, videos=videos, **kwargs)
         return inputs
 
-    def load_videos(self, video_path: str, data_folder=None, fps: int = 1):
+    def load_videos(self, video_path: str, data_folder=None, fps: int = 1, video_kwargs=None):
         assert (
             self.config.video_backend == "qwen_vl_utils"
         ), "Qwen3VLIterableDataset only supports qwen_vl_utils backend"
         if data_folder is not None:
             video_path = os.path.join(data_folder, video_path)
-        frames, video_metadata, sample_fps = self.load_video_qwen_vl_utils(video_path, fps)
+        frames, video_metadata, sample_fps = self.load_video_qwen_vl_utils(video_path, fps, video_kwargs=video_kwargs)
         return frames, video_metadata, sample_fps
 
     def load_video_qwen_vl_utils(
         self,
         video_path: str,
         fps: int,
+        video_kwargs=None,
     ) -> Tuple[np.ndarray, float]:
         """
         Load video using Qwen VL utils.
@@ -75,6 +79,8 @@ class Qwen3VLIterableDataset(VisionSFTIterableDataset):
         Args:
             video_path: Path to video file
             fps: Target frames per second
+            video_kwargs: Optional extra ele fields forwarded to ``fetch_video``
+                (e.g. ``video_start`` / ``video_end`` for sub-clip seek).
 
         Returns:
             Tuple of (video frames, video metadata, sample fps)
@@ -87,6 +93,8 @@ class Qwen3VLIterableDataset(VisionSFTIterableDataset):
             "max_frames": self.config.video_max_frames,
             "min_pixels": self.config.video_min_pixels,
         }
+        if video_kwargs:
+            video_dict.update(video_kwargs)
 
         if self.config.video_sampling_strategy == "frame_num":
             n_frames = self.config.frame_num

--- a/src/lmms_engine/datasets/iterable/vision_iterable_dataset.py
+++ b/src/lmms_engine/datasets/iterable/vision_iterable_dataset.py
@@ -38,10 +38,13 @@ class VisionSFTIterableDataset(MultiModalIterableDataset):
                 if content["type"] == "image_url":
                     images_list.append(content["image_url"]["url"])
                 elif content["type"] == "video_url":
+                    video_url = content["video_url"]
+                    extra = {k: v for k, v in video_url.items() if k != "url" and v is not None}
                     frames, sample_fps = self.load_videos(
-                        content["video_url"]["url"],
+                        video_url["url"],
                         data_folder=data_folder,
                         fps=self.config.fps,
+                        video_kwargs=extra or None,
                     )
                     videos.append(frames)
                     kwargs["fps"] = sample_fps
@@ -73,10 +76,13 @@ class VisionSFTIterableDataset(MultiModalIterableDataset):
                     images_list.append(content["image_url"]["url"])
                 elif content["type"] == "video_url":
                     # Loading videos with fps
+                    video_url = content["video_url"]
+                    extra = {k: v for k, v in video_url.items() if k != "url" and v is not None}
                     frames, sample_fps = self.load_videos(
-                        content["video_url"]["url"],
+                        video_url["url"],
                         data_folder=data_folder,
                         fps=self.config.fps,
+                        video_kwargs=extra or None,
                     )
                     videos.append(frames)
                     # Update kwargs

--- a/src/lmms_engine/datasets/multimodal_mixin.py
+++ b/src/lmms_engine/datasets/multimodal_mixin.py
@@ -3,7 +3,7 @@ import random
 from copy import deepcopy
 from io import BytesIO
 from multiprocessing import cpu_count
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import librosa
 import numpy as np
@@ -100,7 +100,13 @@ class MultiModalDataLoadingMixin:
             audio = librosa.load(audio_path, sr=sr)[0]
         return audio
 
-    def load_videos(self, video_path: str, data_folder=None, fps: int = 1) -> Tuple[np.ndarray, float]:
+    def load_videos(
+        self,
+        video_path: str,
+        data_folder=None,
+        fps: int = 1,
+        video_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[np.ndarray, float]:
         """
         Load video from file path or object storage.
 
@@ -108,6 +114,10 @@ class MultiModalDataLoadingMixin:
             video_path: Path to the video file
             data_folder: Optional folder path to prepend
             fps: Target frames per second
+            video_kwargs: Optional extra fields forwarded to the underlying
+                video backend (e.g. ``video_start`` / ``video_end`` for
+                ``qwen_vl_utils.fetch_video``). Backends that don't support a
+                given key silently ignore it.
 
         Returns:
             Tuple of (video frames, sample fps)
@@ -131,7 +141,7 @@ class MultiModalDataLoadingMixin:
         if self.config.video_backend == "decord":
             return self.load_video_decord(video_path, fps)
         elif self.config.video_backend == "qwen_vl_utils":
-            return self.load_video_qwen_vl_utils(video_path, fps)
+            return self.load_video_qwen_vl_utils(video_path, fps, video_kwargs=video_kwargs)
         elif self.config.video_backend == "qwen_omni_utils":
             return self.load_video_qwen_omni_utils(video_path, fps)
         else:
@@ -177,6 +187,7 @@ class MultiModalDataLoadingMixin:
         self,
         video_path: str,
         fps: int,
+        video_kwargs: Optional[Dict[str, Any]] = None,
     ) -> Tuple[np.ndarray, float]:
         """
         Load video using Qwen VL utils.
@@ -184,6 +195,8 @@ class MultiModalDataLoadingMixin:
         Args:
             video_path: Path to video file
             fps: Target frames per second
+            video_kwargs: Optional extra ele fields forwarded to ``fetch_video``
+                (e.g. ``video_start`` / ``video_end`` for sub-clip seek).
 
         Returns:
             Tuple of (video frames, sample fps)
@@ -196,6 +209,8 @@ class MultiModalDataLoadingMixin:
             "max_frames": self.config.video_max_frames,
             "min_pixels": self.config.video_min_pixels,
         }
+        if video_kwargs:
+            video_dict.update(video_kwargs)
 
         if self.config.video_sampling_strategy == "frame_num":
             is_even = self.config.frame_num % 2 == 0

--- a/src/lmms_engine/protocol/data_proto.py
+++ b/src/lmms_engine/protocol/data_proto.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Union
+from typing import List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -10,6 +10,19 @@ class SFTChatDataText(BaseModel):
 
 class SFTChatDataURL(BaseModel):
     url: str
+
+
+class SFTChatDataVideoURL(SFTChatDataURL):
+    """Video URL with optional time-window seek.
+
+    ``video_start`` / ``video_end`` (seconds) let a sample reference a sub-clip
+    of a longer source mp4 without having to pre-cut it. Both ends are
+    inclusive of the start, exclusive of the end. ``None`` for either falls
+    back to "use the whole video on that side".
+    """
+
+    video_start: Optional[float] = None
+    video_end: Optional[float] = None
 
 
 class SFTChatDataImage(BaseModel):
@@ -24,7 +37,7 @@ class SFTChatDataAudio(BaseModel):
 
 class SFTChatDataVideo(BaseModel):
     type: Literal["video_url"]
-    video_url: SFTChatDataURL
+    video_url: SFTChatDataVideoURL
 
 
 # Hf dataset needs field to be the same across columns


### PR DESCRIPTION
## Summary

Lets a sample reference a sub-clip of a longer source mp4 by attaching
\`video_start\` / \`video_end\` (seconds) directly to its \`video_url\`,
without having to pre-cut the file. Useful for datasets like LiveCC and
Inf-Stream where many samples share a single multi-hour mp4.

## Changes

- **\`protocol/data_proto.py\`**: new \`SFTChatDataVideoURL\` extending
  \`SFTChatDataURL\` with optional \`video_start\` / \`video_end\` floats.
  \`SFTChatDataVideo.video_url\` now uses this type. Existing data without
  these fields is unaffected.
- **\`datasets/multimodal_mixin.py\`**: \`load_videos\` and
  \`load_video_qwen_vl_utils\` accept an optional \`video_kwargs: Dict[str, Any]\`
  that is merged into the \`fetch_video\` ele dict. Backends that don't
  recognise a key silently ignore it.
- **\`datasets/iterable/qwen3_vl_iterable_dataset.py\`** &
  **\`datasets/iterable/vision_iterable_dataset.py\`**: call sites now
  forward all non-\`url\` fields from the \`video_url\` dict as \`video_kwargs\`.

The \`video_kwargs\` indirection (vs. dedicated \`video_start\`/\`video_end\`
parameters) lets future per-sample fetch_video options be added without
churning the interface again.

## Notes

- \`naive/llava_video_dataset.py\` left untouched per request.
- \`fetch_video\` already supports \`video_start\` / \`video_end\` natively in
  decord / torchcodec / torchvision backends, so no backend code change.