### PR TITLE
fix(bagel): guard flash_attn imports so models init works without it

### DIFF
--- a/src/lmms_engine/models/bagel/qwen2_navit.py
+++ b/src/lmms_engine/models/bagel/qwen2_navit.py
@@ -16,7 +16,11 @@ from functools import partial
 from typing import List, Optional, Tuple
 
 import torch
-from flash_attn import flash_attn_varlen_func
+
+try:
+    from flash_attn import flash_attn_varlen_func
+except ImportError:
+    flash_attn_varlen_func = None
 from torch import nn
 from torch.nn.attention import SDPBackend, sdpa_kernel
 from torch.nn.attention.flex_attention import flex_attention

--- a/src/lmms_engine/models/bagel/siglip_navit.py
+++ b/src/lmms_engine/models/bagel/siglip_navit.py
@@ -11,7 +11,11 @@
 # This modified file is released under the same license.
 
 import torch
-from flash_attn import flash_attn_varlen_func
+
+try:
+    from flash_attn import flash_attn_varlen_func
+except ImportError:
+    flash_attn_varlen_func = None
 from torch import nn
 from transformers.activations import ACT2FN
 


### PR DESCRIPTION
## Summary

`lmms_engine.models` has been failing to import in any environment without `flash-attn` installed because two files in `bagel/` import `flash_attn_varlen_func` at module top level without guarding:

- `src/lmms_engine/models/bagel/qwen2_navit.py:19`
- `src/lmms_engine/models/bagel/siglip_navit.py:14`

Since `lmms_engine.models.__init__` eagerly imports `bagel`, this propagates to **every** model — defeating the SDPA fallback added in #163.

This PR wraps both imports in `try/except ImportError`, leaving `flash_attn_varlen_func = None` when unavailable. Bagel itself still needs flash-attn at runtime; this only fixes the import path so unrelated models stay usable.

## Why now

Without this fix, the SDPA backend in `lmms_engine.kernels.attention` is effectively unreachable for any user who hasn't installed flash-attn — the import explodes long before any model code runs.

## Verification

\`\`\`bash
python -c "
import sys
sys.modules['flash_attn'] = None  # simulate not installed
import lmms_engine.models
print('ok')
"
# -> ok
\`\`\`

## Out of scope

- Migrating bagel's attention calls to the unified \`varlen_attn(..., backend=...)\` dispatcher (would let bagel itself run on SDPA). Can be a follow-up; bagel still imports plenty of other flash-attn-only paths through its monkey patches.