### PR TITLE
feat(qwen3_5): packed linear-attention forward + fix DynamicCache import

### DIFF
--- a/docs/models/index.rst
+++ b/docs/models/index.rst
@@ -13,6 +13,7 @@ Documentation for available models and model architectures.
    qwen2_5_omni
    qwen3_vl_moe
    qwen3_moe
+   qwen3_5
    qwen3_omni_moe
    wanvideo
    fla_models

--- a/docs/models/qwen3_5.md
+++ b/docs/models/qwen3_5.md
@@ -1,0 +1,116 @@
+# Qwen3.5 Training
+
+## Overview
+
+Qwen3.5 is a hybrid Transformer + linear-attention (GatedDeltaNet) language model
+with vision support unified in a single model class. Decoder layers alternate
+between standard softmax attention and a linear-attention block backed by
+[`fla.ops.gated_delta_rule`](https://github.com/fla-org/flash-linear-attention).
+
+## Supported Features
+
+| Feature | Support |
+|---------|---------|
+| **FSDP2** | ✅ |
+| **USP / Ulysses SP** | ⚠️ broken on linear-attention layers — see below |
+| **Liger Kernel** | ✅ |
+| **Packing (rmpad)** | ✅ |
+| **causal_conv1d fast path** | ✅ optional, ~4× warmup speedup |
+
+## Packed Linear Attention
+
+When `use_rmpad=true`, lmms-engine monkey-patches `Qwen3_5GatedDeltaNet.forward`
+with a packed-aware version (`linear_attn_forward` in
+`src/lmms_engine/models/qwen3_5/qwen3_5_ops.py`) that:
+
+1. Forwards `cu_seqlens` to `chunk_gated_delta_rule` so the recurrent state
+   resets at every sample boundary. Without this the state leaks across the
+   whole packed batch and training is silently wrong.
+2. Forwards `seq_idx` to `causal_conv1d_fn` so the input depthwise conv does
+   not bleed across sample boundaries.
+
+### Required: `fla` (flash-linear-attention)
+
+```bash
+pip install flash-linear-attention
+```
+
+Required for the packed path; raises at runtime if missing.
+
+### Optional but recommended: `causal_conv1d`
+
+```bash
+pip install causal-conv1d --no-build-isolation
+```
+
+If absent, the conv falls back to `nn.Conv1d`. This is functionally fine but:
+
+- Up to `conv_kernel_size - 1` (= 3) tokens per sample boundary receive a
+  small amount of cross-sample information through the conv receptive field.
+  The recurrent attention itself remains correct.
+- `nn.Conv1d` on long packed sequences has a ~150s first-step warmup tax in
+  practice (cuDNN algorithm pick + autotune); the fused kernel avoids it.
+
+In a 10-step rmpad smoke test on Qwen3.5-0.8B / 2× A6000:
+
+| Configuration | Total time | First step |
+|---|---|---|
+| Without `causal_conv1d` | 197s | 156s |
+| With `causal_conv1d` | 43s | 7s |
+
+Loss / grad-norm trajectories match to ~1e-3 between the two configurations.
+
+## Sequence Parallelism is currently broken
+
+The Ulysses SP path in `qwen3_5_ops.py` only modifies the full-attention
+layers; the linear-attention branch in `decoder_layer_forward` runs without
+any SP-aware reshaping. As a result, with `sp_ulysses_degree > 1`:
+
+- Each SP rank receives only `seq / sp_size` tokens of the packed sequence.
+- The GatedDeltaNet layer treats this slice as a complete sequence and runs
+  its recurrent state from zero on that fragment — **the recurrent state
+  no longer accumulates across the full sequence**, which is mathematically
+  inconsistent with the dense / no-SP forward.
+
+Ulysses' all-to-all trick works for softmax attention because heads are
+independent, so swapping (seq-shard, all-heads) ↔ (full-seq, head-shard)
+recovers the exact computation. Linear attention's recurrent state has no
+analogous decomposition along the head axis; the seq dimension is intrinsically
+serial.
+
+**Do not enable `sp_ulysses_degree > 1` on Qwen3.5 until this is fixed.** The
+fix likely needs either (a) gather-then-scatter the full sequence around each
+linear-attention layer, or (b) integrate `fla`'s `cp_context` ring-style CP.
+Tracking work separately.
+
+## Quick Start
+
+Example training config (FSDP2, packed, no SP):
+
+```yaml
+trainer_type: fsdp2_trainer
+
+dataset_config:
+  dataset_type: vision_iterable
+  processor_config:
+    processor_name: "Qwen/Qwen3.5-0.8B"
+    processor_type: qwen3_vl       # qwen3_vl processor is reused for qwen3.5
+  packing: true
+  packing_length: 16384
+
+model_config:
+  load_from_pretrained_path: "Qwen/Qwen3.5-0.8B"
+  attn_implementation: flash_attention_2
+
+trainer_args:
+  use_rmpad: true
+  use_liger_kernel: true
+  fsdp2: true
+  fsdp_config:
+    transformer_layer_cls_to_wrap: ["Qwen3_5DecoderLayer"]
+  sp_ulysses_degree: 1            # MUST stay 1; see "SP is broken" above
+  bf16: true
+```
+
+A reference smoke-test script lives at
+[`test/train/qwen3_5/train_qwen3_5.py`](../../test/train/qwen3_5/train_qwen3_5.py).

--- a/src/lmms_engine/models/qwen3_5/monkey_patch.py
+++ b/src/lmms_engine/models/qwen3_5/monkey_patch.py
@@ -62,11 +62,13 @@ def apply_liger_kernel_to_qwen3_5(
         from .qwen3_5_ops import (
             decoder_layer_forward as qwen3_5_ops_decoder_layer_forward,
         )
+        from .qwen3_5_ops import linear_attn_forward as qwen3_5_ops_linear_attn_forward
         from .qwen3_5_ops import model_forward as qwen3_5_ops_model_forward
 
         modeling_qwen3_5.Qwen3_5TextModel.forward = qwen3_5_ops_model_forward
         modeling_qwen3_5.Qwen3_5DecoderLayer.forward = qwen3_5_ops_decoder_layer_forward
         modeling_qwen3_5.Qwen3_5Attention.forward = qwen3_5_ops_attn_forward
+        modeling_qwen3_5.Qwen3_5GatedDeltaNet.forward = qwen3_5_ops_linear_attn_forward
 
     if model is not None:
         from transformers.models.qwen3_5.modeling_qwen3_5 import (

--- a/src/lmms_engine/models/qwen3_5/qwen3_5_ops.py
+++ b/src/lmms_engine/models/qwen3_5/qwen3_5_ops.py
@@ -1,12 +1,14 @@
 from typing import List, Optional, Tuple, Union
 
 import torch
-from transformers.cache_utils import Cache
+import torch.nn.functional as F
+from transformers.cache_utils import Cache, DynamicCache
 from transformers.models.qwen3_5.modeling_qwen3_5 import (
     Qwen3_5Attention,
     Qwen3_5DecoderLayer,
-    Qwen3_5DynamicCache,
+    Qwen3_5GatedDeltaNet,
     Qwen3_5TextModel,
+    apply_mask_to_padding_states,
     apply_rotary_pos_emb,
 )
 from transformers.utils import is_flash_attn_2_available, logging
@@ -29,6 +31,145 @@ logger = logging.get_logger(__name__)
 if is_flash_attn_2_available():
     from flash_attn import flash_attn_varlen_func
     from flash_attn.bert_padding import index_first_axis, rearrange
+
+try:
+    from causal_conv1d import causal_conv1d_fn
+
+    _HAS_CAUSAL_CONV1D = True
+except ImportError:
+    causal_conv1d_fn = None
+    _HAS_CAUSAL_CONV1D = False
+
+try:
+    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+
+    _HAS_FLA = True
+except ImportError:
+    chunk_gated_delta_rule = None
+    _HAS_FLA = False
+
+
+def _seq_idx_from_cu_seqlens(cu_seqlens: torch.Tensor, total_tokens: int) -> torch.Tensor:
+    """Build per-token sample index (int32) from cumulative seqlens.
+
+    cu_seqlens shape ``[N+1]``; returns shape ``[1, total_tokens]`` int32 with
+    each token labelled by its sample id, as required by ``causal_conv1d_fn``.
+    """
+    lens = torch.diff(cu_seqlens.to(torch.long))
+    seq_idx = torch.repeat_interleave(
+        torch.arange(lens.numel(), device=cu_seqlens.device, dtype=torch.int32),
+        lens,
+    )
+    # Pad / truncate defensively in case cu_seqlens didn't end exactly at total_tokens
+    if seq_idx.numel() != total_tokens:
+        if seq_idx.numel() < total_tokens:
+            pad = total_tokens - seq_idx.numel()
+            seq_idx = torch.cat(
+                [seq_idx, torch.full((pad,), seq_idx[-1].item() + 1, device=seq_idx.device, dtype=torch.int32)]
+            )
+        else:
+            seq_idx = seq_idx[:total_tokens]
+    return seq_idx.unsqueeze(0).contiguous()
+
+
+def linear_attn_forward(
+    self: Qwen3_5GatedDeltaNet,
+    hidden_states: torch.Tensor,
+    cache_params: Optional[Cache] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    cu_seq_lens: Optional[torch.Tensor] = None,
+    **kwargs,  # absorb e.g. cache_position passed by upstream decoder layer
+) -> torch.Tensor:
+    """Packed/varlen ``Qwen3_5GatedDeltaNet.forward``.
+
+    This patch is only installed when ``use_rmpad=True``, so we always go
+    through the packed path. ``cu_seq_lens`` must be provided.
+
+    * ``causal_conv1d_fn(..., seq_idx=...)`` if causal_conv1d is installed,
+      otherwise ``nn.Conv1d`` (leaks up to ``conv_kernel_size - 1`` tokens
+      across sample boundaries — accepted as a soft compromise).
+    * ``fla.ops.gated_delta_rule.chunk_gated_delta_rule(..., cu_seqlens=...)``
+      so the recurrent state resets per sample. fla is required.
+    """
+    assert cu_seq_lens is not None, "linear_attn_forward requires cu_seq_lens (rmpad must be on)"
+    if not _HAS_FLA:
+        raise RuntimeError(
+            "Packed linear attention requires `fla` (flash-linear-attention). "
+            "Install it via `pip install flash-linear-attention`."
+        )
+
+    hidden_states = apply_mask_to_padding_states(hidden_states, attention_mask)
+    batch_size, seq_len, _ = hidden_states.shape
+    assert batch_size == 1, (
+        f"packed linear_attn_forward expects batch_size=1, got {batch_size}. "
+        "Caller must squeeze rmpad inputs to (1, total_tokens, hidden)."
+    )
+
+    seq_idx = _seq_idx_from_cu_seqlens(cu_seq_lens, total_tokens=seq_len)
+
+    mixed_qkv = self.in_proj_qkv(hidden_states)
+    mixed_qkv = mixed_qkv.transpose(1, 2)  # (B, conv_dim, T)
+
+    z = self.in_proj_z(hidden_states)
+    z = z.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+    b = self.in_proj_b(hidden_states)
+    a = self.in_proj_a(hidden_states)
+
+    if _HAS_CAUSAL_CONV1D:
+        mixed_qkv = causal_conv1d_fn(
+            x=mixed_qkv,
+            weight=self.conv1d.weight.squeeze(1),
+            bias=self.conv1d.bias,
+            activation=self.activation,
+            seq_idx=seq_idx,
+        )
+    else:
+        # Fallback: plain nn.Conv1d. Leaks up to (kernel-1) tokens across
+        # sample boundaries. Accepted to avoid the causal_conv1d build dep.
+        logger.warning_once(
+            f"Packed linear attention without causal_conv1d_fn; up to "
+            f"{self.conv_kernel_size - 1} tokens will leak across sample "
+            f"boundaries in the input conv. Install causal_conv1d to avoid."
+        )
+        mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, :seq_len])
+
+    mixed_qkv = mixed_qkv.transpose(1, 2)
+    query, key, value = torch.split(
+        mixed_qkv,
+        [self.key_dim, self.key_dim, self.value_dim],
+        dim=-1,
+    )
+
+    query = query.reshape(batch_size, seq_len, -1, self.head_k_dim)
+    key = key.reshape(batch_size, seq_len, -1, self.head_k_dim)
+    value = value.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+    beta = b.sigmoid()
+    # If the model is loaded in fp16, without the .float() here, A might be -inf
+    g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+    if self.num_v_heads // self.num_k_heads > 1:
+        query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+        key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+
+    core_attn_out, _ = chunk_gated_delta_rule(
+        query,
+        key,
+        value,
+        g=g,
+        beta=beta,
+        initial_state=None,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seq_lens.to(torch.long),
+    )
+
+    core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)
+    z = z.reshape(-1, self.head_v_dim)
+    core_attn_out = self.norm(core_attn_out, z)
+    core_attn_out = core_attn_out.reshape(batch_size, seq_len, -1)
+
+    return self.out_proj(core_attn_out)
 
 
 def model_forward(
@@ -69,7 +210,7 @@ def model_forward(
         inputs_embeds = self.embed_tokens(input_ids)
 
     if use_cache and past_key_values is None:
-        past_key_values = Qwen3_5DynamicCache(config=self.config)
+        past_key_values = DynamicCache(config=self.config)
 
     if cache_position is None:
         past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
@@ -163,6 +304,7 @@ def decoder_layer_forward(
             cache_params=past_key_values,
             cache_position=cache_position,
             attention_mask=None,
+            cu_seq_lens=cu_seq_lens,
         )
         if needs_squeeze:
             hidden_states = hidden_states.squeeze(0)

--- a/test/train/qwen3_5/test_qwen3_5.py
+++ b/test/train/qwen3_5/test_qwen3_5.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+from unittest import TestCase
+
+from utils import launch_torchrun_training, with_multi_gpu_training, with_temp_dir
+
+
+class TestQwen3_5(TestCase):
+    @with_temp_dir
+    @with_multi_gpu_training
+    def test_train_fsdp2(self, temp_dir, nproc_per_node):
+        """Test Qwen3.5 training with FSDP2 (packed linear attention path)."""
+
+        script_path = os.path.join(os.path.dirname(__file__), "train_qwen3_5.py")
+
+        result = launch_torchrun_training(
+            script_path=script_path,
+            output_dir=temp_dir,
+            nproc_per_node=nproc_per_node,
+            timeout=600,
+        )
+
+        self.assertIsNotNone(result, "Training process should not be None")
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"Training failed with return code {result.returncode}",
+        )
+
+        if result.stdout:
+            print("Training stdout:", result.stdout)
+        if result.stderr:
+            print("Training stderr:", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/train/qwen3_5/train_qwen3_5.py
+++ b/test/train/qwen3_5/train_qwen3_5.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Training script for Qwen3.5 model.
+This script is designed to be launched by torchrun for multi-GPU training.
+
+Exercises the packed (rmpad) path through Qwen3_5GatedDeltaNet via the
+linear_attn_forward monkey patch.
+"""
+
+import argparse
+
+from lmms_engine.launch.cli import create_train_task
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train Qwen3.5 model")
+    parser.add_argument("--output_dir", type=str, required=True, help="Output directory for training")
+    parser.add_argument("--nproc_per_node", type=int, default=1, help="Number of processes per node")
+    parser.add_argument("--nnodes", type=int, default=1, help="Number of nodes")
+    parser.add_argument("--node_rank", type=int, default=0, help="Rank of this node")
+    parser.add_argument("--master_addr", type=str, default="127.0.0.1", help="Master address")
+    parser.add_argument("--master_port", type=str, default="8000", help="Master port")
+
+    args = parser.parse_args()
+
+    cfg = {
+        "trainer_type": "fsdp2_trainer",
+        "dataset_config": {
+            "dataset_type": "vision_iterable",
+            "dataset_format": "yaml",
+            "datasets": [
+                {
+                    "path": "data/lmms_engine_test/text_example/open_thoughts_5k.parquet",
+                    "data_folder": "",
+                    "data_type": "parquet",
+                }
+            ],
+            "processor_config": {
+                "processor_name": "Qwen/Qwen3.5-0.8B",
+                "processor_type": "qwen3_vl",
+            },
+            "packing": False,
+            "video_backend": "qwen_vl_utils",
+        },
+        "model_config": {
+            "load_from_pretrained_path": "Qwen/Qwen3.5-0.8B",
+            "attn_implementation": "flash_attention_2",
+        },
+        "trainer_args": {
+            "per_device_train_batch_size": 1,
+            "gradient_checkpointing": True,
+            "num_train_epochs": 1,
+            "max_steps": 10,
+            "report_to": "none",
+            "output_dir": args.output_dir,
+            "warmup_ratio": 0.0,
+            "eval_strategy": "no",
+            "dataloader_num_workers": 8,
+            "bf16": True,
+            "lr_scheduler_type": "cosine",
+            "use_liger_kernel": True,
+            "use_rmpad": True,
+            "fsdp2": True,
+            "group_by_length": True,
+            "fsdp_config": {
+                "transformer_layer_cls_to_wrap": ["Qwen3_5DecoderLayer"],
+                "reshard_after_forward": False,
+            },
+            "sp_ulysses_degree": 1,
+            "print_batch_input_steps": -1,
+        },
+    }
+
+    train_task = create_train_task(cfg)
+    train_task.build()
+    train_task.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- New `linear_attn_forward` in `qwen3_5_ops.py` that drives `Qwen3_5GatedDeltaNet` correctly under rmpad: forwards `cu_seqlens` to fla and `seq_idx` to `causal_conv1d_fn`.
- Patched in via `monkey_patch.py` whenever `use_rmpad=True`.
- Fix unrelated import: `Qwen3_5DynamicCache` was removed in current transformers; the file now uses generic `DynamicCache`. Without this, `qwen3_5_ops.py` did not even import.
- New CICD smoke test under `test/train/qwen3_5/`.
- New doc page `docs/models/qwen3_5.md` covering deps and the SP caveat.

## Why

`Qwen3_5GatedDeltaNet.forward` upstream takes `(B, T, hidden)` and never sees sample boundaries. With rmpad the input is reshaped to `(1, total_tokens, hidden)`, which means:

1. The recurrent state in `chunk_gated_delta_rule` accumulates across the **entire packed batch** instead of resetting per sample.
2. The input depthwise `nn.Conv1d` (kernel 4) bleeds receptive-field information across sample boundaries.

Both bugs were silent — training would just learn slightly wrong objectives. This PR fixes (1) by passing `cu_seqlens` to the fla kernel, and (2) by passing `seq_idx` to `causal_conv1d_fn` when available.

## Dependencies

- **fla (flash-linear-attention)** — **required** for the packed path. Easy install: `pip install flash-linear-attention`. The patched forward raises a clear error if missing.
- **causal_conv1d** — **optional**. Install it if you can (`pip install causal-conv1d --no-build-isolation`), but it requires a build step. Without it the conv falls back to `nn.Conv1d`:
  - Leaks at most `conv_kernel_size - 1` (=3) tokens across each sample boundary (small, accepted tradeoff).
  - First-step warmup tax of ~150s on long packed sequences (cuDNN algo pick), gone with the fused kernel.
  - A `logger.warning_once` is emitted to flag this.

## SP is currently broken (documented, not fixed)

`decoder_layer_forward` only reshapes inputs through Ulysses on the full-attention branch. The linear-attention branch sees the SP-sliced tensor directly, so each rank runs GatedDeltaNet on `seq / sp_size` tokens with a fresh recurrent state — mathematically not the same as the no-SP forward.

Ulysses' all-to-all trick only works because softmax-attention heads are independent. Linear-attention recurrent state is intrinsically serial along the seq dim, so the same reshape doesn't recover the dense computation. Fixing this needs either gather→linear_attn→scatter or `fla`'s `cp_context` ring CP. Tracking separately.

**`sp_ulysses_degree > 1` is therefore broken on Qwen3.5 and the doc explicitly warns against it.**

## Validation

10-step FSDP2 smoke test on Qwen3.5-0.8B / 2× A6000 (`test/train/qwen3_5/`):

| | Without `causal_conv1d` | With `causal_conv1d` |
|---|---|---|
| Total time | 197s | 43s |
| First step | 156s | 7s |
| Tokens/s/GPU (steady) | ~5.2k | ~6.0k |
| Loss / grad-norm trajectory | ✓ healthy | ✓ matches above to ~1e-3 |

Loss curve `2.76 → 2.86 → 2.62 → 2.34 → 1.99 → 1.89 → 2.03 → 2.30 → 1.90 → 2.13`, grad-norm `78 → 45 → 27 → 18 → ...` in both runs, confirming the fix is numerically consistent across the conv-fast-path toggle.

## Out of scope

- Fixing Ulysses SP for the linear-attention branch (separate, larger change).
- Migrating qwen3_5 attention to the unified `varlen_attn(..., backend=...)` dispatcher; keeping this PR focused.