### PR TITLE
feat(qwen3_5): sequence parallel + ViT frame parallel integration

### DIFF
--- a/src/lmms_engine/models/qwen3_5/monkey_patch.py
+++ b/src/lmms_engine/models/qwen3_5/monkey_patch.py
@@ -134,27 +134,40 @@ def apply_liger_kernel_to_qwen3_5(
 def apply_vit_frame_parallel_to_qwen3_5(model: PreTrainedModel = None, **kwargs) -> None:
     """Wrap ``Qwen3_5VisionModel.forward`` with frame-parallel dispatch.
 
-    Frames are redistributed across the DP group via LPT so each rank handles
-    a balanced number of ViT patches. ``pgm.process_group_manager.dp_group``
-    must be initialized before this runs.
+    Frames are redistributed across the flat ``dp_cp_group`` (dp × cp) via
+    LPT so each rank handles a balanced number of ViT patches. Under SP
+    (cp_size > 1) only ``cp_rank == 0`` contributes frames to the pool — the
+    other cp ranks see duplicated dataloader input and would otherwise
+    double-count. After the ViT forward, features flow back to ``cp_rank ==
+    0`` via reverse all_to_all, then broadcast inside the cp group so every
+    rank can do ``masked_scatter`` *before* the LM applies SP slicing.
+
+    ``pgm.process_group_manager`` must be initialized before this runs.
     """
     from transformers.models.qwen3_5 import modeling_qwen3_5
 
     from .qwen3_5_vit_ops import input_dispatch, output_dispatch
 
-    if pgm.process_group_manager is None or pgm.process_group_manager.dp_world_size <= 1:
-        logger.info("vit_frame_parallel: dp_world_size <= 1, skipping ViT wrap")
+    if pgm.process_group_manager is None:
+        logger.info("vit_frame_parallel: process_group_manager not initialized, skipping ViT wrap")
         return
 
-    dp_group = pgm.process_group_manager.dp_group
+    dp_cp_world_size = pgm.process_group_manager.dp_cp_world_size
+    if dp_cp_world_size <= 1:
+        logger.info("vit_frame_parallel: dp_cp_world_size <= 1, skipping ViT wrap")
+        return
+
+    dp_cp_group = pgm.process_group_manager.dp_cp_group
+    cp_group = pgm.process_group_manager.cp_group if pgm.process_group_manager.cp_world_size > 1 else None
     orig_forward = modeling_qwen3_5.Qwen3_5VisionModel.forward
 
     wrapped = wrap_vit_forward(
-        input_dispatch=partial(input_dispatch, group=dp_group),
+        input_dispatch=partial(input_dispatch, group=dp_cp_group, cp_group=cp_group),
         orig_forward=orig_forward,
         output_dispatch=output_dispatch,
     )
     modeling_qwen3_5.Qwen3_5VisionModel.forward = wrapped
     logger.info(
-        f"vit_frame_parallel: wrapped Qwen3_5VisionModel.forward (dp_size={pgm.process_group_manager.dp_world_size})"
+        f"vit_frame_parallel: wrapped Qwen3_5VisionModel.forward "
+        f"(dp_cp_size={dp_cp_world_size}, cp_size={pgm.process_group_manager.cp_world_size})"
     )

--- a/src/lmms_engine/models/qwen3_5/monkey_patch.py
+++ b/src/lmms_engine/models/qwen3_5/monkey_patch.py
@@ -79,6 +79,17 @@ def apply_liger_kernel_to_qwen3_5(
         modeling_qwen3_5.Qwen3_5Attention.forward = qwen3_5_ops_attn_forward
         modeling_qwen3_5.Qwen3_5GatedDeltaNet.forward = qwen3_5_ops_linear_attn_forward
 
+        # Ulysses SP: slice `inputs_embeds` along the packed seq dim on entry
+        # to the text model so each rank holds `total_tokens / sp_size`
+        # contiguous tokens. The full-attention layer all-to-alls back to a
+        # full seq inside `attn_forward`; the linear-attention layer keeps the
+        # shard and runs fla's CP path with `build_cp_context`.
+        from ...parallel.sequence_parallel.ulysses import (
+            patch_vlm_for_ulysses_input_slicing,
+        )
+
+        patch_vlm_for_ulysses_input_slicing(modeling_qwen3_5.Qwen3_5TextModel)
+
     # Replace VisionPatchEmbed.forward with a Linear path. Mathematically
     # equivalent to the upstream Conv3d (kernel == stride), but avoids cudnn
     # falling back to a slow Conv3d kernel on packed varlen ViT inputs.

--- a/src/lmms_engine/models/qwen3_5/qwen3_5_ops.py
+++ b/src/lmms_engine/models/qwen3_5/qwen3_5_ops.py
@@ -28,6 +28,16 @@ from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
 )
 from transformers.utils import is_flash_attn_2_available, logging
 
+from ...parallel.sequence_parallel.ulysses import (
+    gather_heads_scatter_seq,
+    gather_seq_scatter_heads,
+    get_ulysses_sequence_parallel_group,
+    get_ulysses_sequence_parallel_rank,
+    get_ulysses_sequence_parallel_world_size,
+    repeat_kv,
+    ulysses_pad,
+    validate_ulysses_config,
+)
 from ..common_ops.rope import qwen3_vl_get_rope_index
 
 
@@ -64,6 +74,16 @@ try:
 except ImportError:
     chunk_gated_delta_rule = None
     _HAS_FLA = False
+
+try:
+    from fla.modules.conv.cp.ops import causal_conv1d_cp
+    from fla.ops.cp.context import build_cp_context
+
+    _HAS_FLA_CP = True
+except ImportError:
+    causal_conv1d_cp = None
+    build_cp_context = None
+    _HAS_FLA_CP = False
 
 
 def patch_embed_forward(
@@ -129,6 +149,18 @@ def linear_attn_forward(
       across sample boundaries — accepted as a soft compromise).
     * ``fla.ops.gated_delta_rule.chunk_gated_delta_rule(..., cu_seqlens=...)``
       so the recurrent state resets per sample. fla is required.
+
+    Sequence parallel (Ulysses SP world size > 1):
+
+    * Linear attention can **not** use the Ulysses all-to-all trick (the
+      recurrent state runs sequentially along the seq dim, so swapping
+      heads <-> seq would collapse all tokens onto a single rank). Instead
+      we use fla's Context Parallel: each rank keeps its local seq shard,
+      builds an ``FLACPContext`` from the *global* ``cu_seq_lens`` so the
+      kernel knows where the sample boundaries fall on every rank, and we
+      manually do the causal-conv1d halo exchange (``conv_kernel_size - 1``
+      tokens from the previous rank are prepended before the conv and
+      stripped off afterwards).
     """
     assert cu_seq_lens is not None, "linear_attn_forward requires cu_seq_lens (rmpad must be on)"
     if not _HAS_FLA:
@@ -144,10 +176,26 @@ def linear_attn_forward(
         "Caller must squeeze rmpad inputs to (1, total_tokens, hidden)."
     )
 
-    seq_idx = _seq_idx_from_cu_seqlens(cu_seq_lens, total_tokens=seq_len)
+    # ---- (optional) FLA context-parallel setup ----
+    # Under SP, build an ``FLACPContext`` from the *global* ``cu_seq_lens``.
+    # The context carries local cu_seqlens, sample-boundary-aware conv-halo
+    # metadata, and the SP process group. Both ``causal_conv1d_cp`` and
+    # ``chunk_gated_delta_rule`` consume the context directly.
+    if get_ulysses_sequence_parallel_world_size() > 1:
+        if not _HAS_FLA_CP:
+            raise RuntimeError(
+                "Sequence parallel for Qwen3.5 linear attention requires fla>=0.4 "
+                "with `fla.ops.cp` / `fla.modules.conv.cp`. Please upgrade fla."
+            )
+        cp_ctx = build_cp_context(
+            cu_seqlens=cu_seq_lens.to(torch.long),
+            group=get_ulysses_sequence_parallel_group(),
+            conv1d_kernel_size=self.conv_kernel_size,
+        )
+    else:
+        cp_ctx = None
 
     mixed_qkv = self.in_proj_qkv(hidden_states)
-    mixed_qkv = mixed_qkv.transpose(1, 2)  # (B, conv_dim, T)
 
     z = self.in_proj_z(hidden_states)
     z = z.reshape(batch_size, seq_len, -1, self.head_v_dim)
@@ -155,7 +203,25 @@ def linear_attn_forward(
     b = self.in_proj_b(hidden_states)
     a = self.in_proj_a(hidden_states)
 
-    if _HAS_CAUSAL_CONV1D:
+    # ---- causal conv1d ----
+    # Under SP: use fla's CP-aware conv (it talks to the previous rank to set
+    # up the conv1d ``initial_state`` and handles backward gradient sync).
+    # Without SP: keep the fast Tri Dao ``causal_conv1d_fn`` (with ``seq_idx``
+    # to respect packed sample boundaries).
+    if cp_ctx is not None:
+        # fla wants (B, T, D); Tri Dao wants (B, D, T). We never did the
+        # transpose, so just pass mixed_qkv straight through.
+        mixed_qkv = causal_conv1d_cp(
+            x=mixed_qkv,
+            weight=self.conv1d.weight.squeeze(1),
+            bias=self.conv1d.bias,
+            activation=self.activation,
+            cp_context=cp_ctx,
+        )
+    elif _HAS_CAUSAL_CONV1D:
+        # Tri Dao kernel: needs channel-last (B, D, T)
+        mixed_qkv = mixed_qkv.transpose(1, 2)
+        seq_idx = _seq_idx_from_cu_seqlens(cu_seq_lens, total_tokens=seq_len)
         mixed_qkv = causal_conv1d_fn(
             x=mixed_qkv,
             weight=self.conv1d.weight.squeeze(1),
@@ -163,6 +229,7 @@ def linear_attn_forward(
             activation=self.activation,
             seq_idx=seq_idx,
         )
+        mixed_qkv = mixed_qkv.transpose(1, 2)
     else:
         # Fallback: plain nn.Conv1d. Leaks up to (kernel-1) tokens across
         # sample boundaries. Accepted to avoid the causal_conv1d build dep.
@@ -171,9 +238,10 @@ def linear_attn_forward(
             f"{self.conv_kernel_size - 1} tokens will leak across sample "
             f"boundaries in the input conv. Install causal_conv1d to avoid."
         )
+        mixed_qkv = mixed_qkv.transpose(1, 2)
         mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, :seq_len])
+        mixed_qkv = mixed_qkv.transpose(1, 2)
 
-    mixed_qkv = mixed_qkv.transpose(1, 2)
     query, key, value = torch.split(
         mixed_qkv,
         [self.key_dim, self.key_dim, self.value_dim],
@@ -191,17 +259,32 @@ def linear_attn_forward(
         query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
         key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
-    core_attn_out, _ = chunk_gated_delta_rule(
-        query,
-        key,
-        value,
-        g=g,
-        beta=beta,
-        initial_state=None,
-        output_final_state=False,
-        use_qk_l2norm_in_kernel=True,
-        cu_seqlens=cu_seq_lens.to(torch.long),
-    )
+    if cp_ctx is not None:
+        # When `cp_context` is given, fla overrides `cu_seqlens` internally
+        # with `cp_context.cu_seqlens` -- do NOT pass cu_seqlens again.
+        core_attn_out, _ = chunk_gated_delta_rule(
+            query,
+            key,
+            value,
+            g=g,
+            beta=beta,
+            initial_state=None,
+            output_final_state=False,
+            use_qk_l2norm_in_kernel=True,
+            cp_context=cp_ctx,
+        )
+    else:
+        core_attn_out, _ = chunk_gated_delta_rule(
+            query,
+            key,
+            value,
+            g=g,
+            beta=beta,
+            initial_state=None,
+            output_final_state=False,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=cu_seq_lens.to(torch.long),
+        )
 
     core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)
     z = z.reshape(-1, self.head_v_dim)
@@ -367,10 +450,13 @@ def attn_forward(
     position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
     **kwargs,
 ):
+    ulysses_sp_size = get_ulysses_sequence_parallel_world_size()
     input_shape = hidden_states.shape[:-1]
     hidden_shape = (*input_shape, -1, self.head_dim)
 
-    # Qwen3.5 uses gated attention: q_proj outputs query + gate (2x size)
+    # Qwen3.5 uses gated attention: q_proj outputs query + gate (2x size).
+    # The gate is per-token and stays seq-sharded -- it is *not* part of the
+    # Ulysses all-to-all dance (which only swaps seq <-> head on Q/K/V).
     query_states, gate = torch.chunk(self.q_proj(hidden_states).view(*input_shape, -1, self.head_dim * 2), 2, dim=-1)
     gate = gate.reshape(*input_shape, -1)
 
@@ -378,6 +464,24 @@ def attn_forward(
     key_states = self.k_norm(self.k_proj(hidden_states).view(hidden_shape))
     value_states = self.v_proj(hidden_states).view(hidden_shape)
     cos, sin = position_embeddings
+
+    ########## AlltoAll for Ulysses ##########
+    if ulysses_sp_size > 1:
+        validate_ulysses_config(query_states.size(-2), ulysses_sp_size)
+        # Repeat KV heads so they divide sp_size (flash-attn handles MQA/GQA
+        # in the kernel; we just need n_heads % sp_size == 0 after this).
+        repeats = max(ulysses_sp_size // key_states.size(-2), 1)
+        if repeats > 1:
+            key_states = key_states.repeat_interleave(repeats, dim=-2)
+            value_states = value_states.repeat_interleave(repeats, dim=-2)
+
+        # (seq/sp, n_head, head_dim) -> (seq, n_head/sp, head_dim)
+        query_states = gather_seq_scatter_heads(query_states, seq_dim=0, head_dim=1)
+        key_states = gather_seq_scatter_heads(key_states, seq_dim=0, head_dim=1)
+        value_states = gather_seq_scatter_heads(value_states, seq_dim=0, head_dim=1)
+
+        # `cu_seq_lens` here is the *global* (already-ulysses-padded) one,
+        # so it lines up with the gathered seq. Nothing to fix.
 
     query_states = query_states.unsqueeze(0).transpose(1, 2)
     key_states = key_states.unsqueeze(0).transpose(1, 2)
@@ -408,8 +512,13 @@ def attn_forward(
         dropout_p=0.0,
     )
 
+    ########## AlltoAll for Ulysses ##########
+    if ulysses_sp_size > 1:
+        # (seq, n_head/sp, head_dim) -> (seq/sp, n_head, head_dim)
+        attn_output = gather_heads_scatter_seq(attn_output, seq_dim=0, head_dim=1)
+
     attn_output = attn_output.reshape(*input_shape, -1).contiguous()
-    # Apply the gated attention mechanism
+    # Apply the gated attention mechanism (gate stays seq-sharded throughout).
     attn_output = attn_output * torch.sigmoid(gate)
     attn_output = self.o_proj(attn_output)
 
@@ -478,6 +587,20 @@ def model_forward(
     position_ids = (
         index_first_axis(rearrange(position_ids, "c b s ... -> (b s) c ..."), indices).transpose(0, 1).unsqueeze(1)
     )
+    if get_ulysses_sequence_parallel_world_size() > 1:
+        # Pad packed seq to a multiple of sp_size. Both Ulysses (full-attn)
+        # and FLA CP (linear-attn) assume each rank holds the same number of
+        # contiguous tokens, so we apply the same padding for both paths.
+        input_ids, position_ids, pad_size = ulysses_pad(
+            input_ids.unsqueeze(0),
+            position_ids,
+            sp_size=get_ulysses_sequence_parallel_world_size(),
+        )
+        input_ids = input_ids.squeeze(0)
+        if pad_size > 0:
+            # Mark the pad span as its own sample so linear-attn / causal-conv
+            # don't leak the pad region back into real samples.
+            cu_seq_lens = torch.cat([cu_seq_lens, cu_seq_lens.new_tensor([cu_seq_lens[-1].item() + pad_size])])
 
     if inputs_embeds is None:
         inputs_embeds = self.get_input_embeddings()(input_ids)

--- a/src/lmms_engine/models/qwen3_5/qwen3_5_vit_ops.py
+++ b/src/lmms_engine/models/qwen3_5/qwen3_5_vit_ops.py
@@ -8,24 +8,40 @@ where
     hidden_states : (total_patches, C*T*P*P)   — packed
     grid_thw      : (num_segments, 3)          — each row contributes T*H*W patches
 
-``input_dispatch`` redistributes frames across the DP group via LPT so each
-rank handles a balanced number of ViT patches, runs the original forward
-locally on the received slice, and the matching ``output_dispatch`` (TODO)
+``input_dispatch`` redistributes frames across the DP (or DP×CP) group via
+LPT so each rank handles a balanced number of ViT patches, runs the original
+forward locally on the received slice, and the matching ``output_dispatch``
 gathers features back so each rank ends up with the features for its own
 original frames.
+
+Sequence-parallel (CP) integration
+----------------------------------
+When SP is on, the dataloader still shards by ``dp_rank`` only, so the
+``cp_rank`` axis sees the *same* frames duplicated. To actually cut ViT
+memory under SP we run frame-balancing on the flat ``dp_cp_group`` (size
+= dp_size × cp_size), but only let ``cp_rank == 0`` contribute frames so
+the LPT load equals the real (de-duplicated) frame count. After the ViT
+forward, features destined for a given dp_rank flow back to its ``cp_rank
+== 0`` worker via the reverse all_to_all, then a CP-group all_reduce
+(autograd-aware) broadcasts them to ``cp_rank > 0`` so every rank can do
+its ``masked_scatter`` *before* the SP layer slices the seq.
 
 Communication:
     * Metadata (per-rank token / frame counts) goes through ``all_gather_object``.
     * ``hidden_states`` uses ``all_to_all_single_autograd`` so gradients route
       back to the originating rank.
     * ``grid_thw`` uses plain ``all_to_all_single`` (no grad needed).
+    * Optional CP broadcast uses autograd-aware ``all_reduce`` (sum), which
+      back-props as another sum — equivalent to broadcasting forward and
+      summing gradients on the source rank.
 """
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.distributed as dist
 from torch.distributed._functional_collectives import (
+    all_reduce,
     all_to_all_single,
     all_to_all_single_autograd,
 )
@@ -44,38 +60,35 @@ def input_dispatch(
     grid_thw: torch.Tensor,
     *,
     group: dist.ProcessGroup,
+    cp_group: Optional[dist.ProcessGroup] = None,
     **kwargs,
 ) -> Tuple[Tuple, Dict[str, Any], Dict[str, Any]]:
-    """Dispatch frames across the DP group ahead of the ViT forward.
+    """Dispatch frames across ``group`` ahead of the ViT forward.
 
-    Returns ``(new_args, new_kwargs, ctx)`` for ``wrap_vit_forward``:
-        new_args / new_kwargs : passed to the original ``Qwen3_5VisionModel.forward``
-        ctx                   : minimal state needed by ``output_dispatch`` to
-                                run the reverse all_to_all (just the group and
-                                the swapped splits).
+    When ``cp_group`` is provided (SP enabled), only ``cp_rank == 0`` workers
+    contribute their frames to the LPT pool; ``cp_rank > 0`` workers report
+    zero frames so they are pure receivers. This matches the dataloader's
+    dp-only sharding (cp ranks within the same dp_rank hold duplicated input).
 
-    Steps:
-        1. Gather each rank's per-frame token counts (``num_tokens``) and
-           frame count via two ``all_gather_object`` calls. Flatten into a
-           global ``loads`` list.
-        2. Run LPT on ``loads`` to get a global ``assignment`` (which rank
-           each global frame belongs to). Deterministic, same on every rank.
-        3. Slice ``assignment`` into the segment owned by this rank to compute
-           src-view ``input_splits`` / ``input_frames`` (how many tokens /
-           frames I send to each dst).
-        4. Walk ``assignment`` to compute src-view ``output_splits`` /
-           ``output_frames`` (how many I receive from each src).
-        5. ``all_to_all_single_autograd`` on ``hidden_states`` (carries grads
-           via the reverse permutation) and plain ``all_to_all_single`` on
-           ``grid_thw`` (metadata only).
+    Returns ``(new_args, new_kwargs, ctx)`` for ``wrap_vit_forward``.
     """
     world_size = dist.get_world_size(group=group)
     my_rank = dist.get_rank(group=group)
     device = hidden_states.device
 
+    # Determine whether this rank is the "source" (contributes frames) within
+    # its cp group. cp_rank > 0 holds duplicated input, so it should not push
+    # frames into the LPT pool.
+    cp_rank = dist.get_rank(group=cp_group) if cp_group is not None else 0
+    is_source = cp_rank == 0
+
     # ---- 1) gather per-rank token/frame counts ----
-    num_tokens = grid_thw.prod(-1).tolist()
-    num_frames = grid_thw.shape[0]
+    if is_source:
+        num_tokens = grid_thw.prod(-1).tolist()
+        num_frames = grid_thw.shape[0]
+    else:
+        num_tokens = []
+        num_frames = 0
     total_tokens = [None for _ in range(world_size)]
     total_frames = [None for _ in range(world_size)]
     dist.all_gather_object(total_tokens, num_tokens, group=group)
@@ -93,9 +106,10 @@ def input_dispatch(
 
     input_splits = [0] * world_size  # tokens I send to each dst
     input_frames = [0] * world_size  # frames I send to each dst
-    for tokens, dst in zip(num_tokens, my_assignment):
-        input_splits[dst] += tokens
-        input_frames[dst] += 1
+    if is_source:
+        for tokens, dst in zip(num_tokens, my_assignment):
+            input_splits[dst] += tokens
+            input_frames[dst] += 1
 
     # ---- 4) src-view output splits (what I receive from each src) ----
     output_splits = [0] * world_size  # tokens I receive from each src
@@ -111,32 +125,36 @@ def input_dispatch(
 
     # ---- 5) permute local tensors so frames are grouped by destination ----
     # all_to_all_single splits the input row-wise in tensor order, so we must
-    # rearrange local frames into [dst=0 block, dst=1 block, ...] first.
-    send_order = torch.argsort(
-        torch.tensor(my_assignment, dtype=torch.long, device=device),
-        stable=True,
-    )
-    # patch-level permutation: each frame contributes T*H*W consecutive rows.
-    patches_per_local = grid_thw.prod(-1)
-    local_starts = torch.cat([torch.zeros(1, dtype=torch.long, device=device), patches_per_local.cumsum(0)])
-    patch_perm = (
-        torch.cat([torch.arange(local_starts[i], local_starts[i + 1], device=device) for i in send_order.tolist()])
-        if num_frames > 0
-        else torch.empty(0, dtype=torch.long, device=device)
-    )
-    hidden_states = hidden_states[patch_perm].contiguous()
-    grid_thw = grid_thw[send_order].contiguous()
+    # rearrange local frames into [dst=0 block, dst=1 block, ...] first. Only
+    # source ranks have real input to permute; cp_rank>0 sends an empty tensor.
+    if is_source and num_frames > 0:
+        send_order = torch.argsort(
+            torch.tensor(my_assignment, dtype=torch.long, device=device),
+            stable=True,
+        )
+        patches_per_local = grid_thw.prod(-1)
+        local_starts = torch.cat([torch.zeros(1, dtype=torch.long, device=device), patches_per_local.cumsum(0)])
+        patch_perm = torch.cat(
+            [torch.arange(local_starts[i], local_starts[i + 1], device=device) for i in send_order.tolist()]
+        )
+        send_hidden = hidden_states[patch_perm].contiguous()
+        send_grid = grid_thw[send_order].contiguous()
+    else:
+        send_order = torch.empty(0, dtype=torch.long, device=device)
+        patches_per_local = torch.empty(0, dtype=torch.long, device=device)
+        send_hidden = hidden_states.new_zeros((0, hidden_states.shape[1]))
+        send_grid = grid_thw.new_zeros((0, grid_thw.shape[1]))
 
     # ---- 6) all_to_all dispatch ----
-    hidden_states = all_to_all_single_autograd(
-        hidden_states,
+    recv_hidden = all_to_all_single_autograd(
+        send_hidden,
         output_split_sizes=output_splits,
         input_split_sizes=input_splits,
         group=group,
     )
 
-    grid_thw = all_to_all_single(
-        grid_thw,
+    recv_grid = all_to_all_single(
+        send_grid,
         output_split_sizes=output_frames,
         input_split_sizes=input_frames,
         group=group,
@@ -144,14 +162,17 @@ def input_dispatch(
 
     ctx = {
         "group": group,
+        "cp_group": cp_group,
         # Swap on the way back.
         "input_splits": output_splits,
         "output_splits": input_splits,
-        # Inverse permutation for un-shuffling features back to local-original frame order.
+        # Inverse permutation for un-shuffling features back to local-original
+        # frame order (only meaningful on source ranks).
         "send_order": send_order,
         "patches_per_local": patches_per_local,
+        "is_source": is_source,
     }
-    return (self, hidden_states), {"grid_thw": grid_thw, **kwargs}, ctx
+    return (self, recv_hidden), {"grid_thw": recv_grid, **kwargs}, ctx
 
 
 def output_dispatch(out, ctx):
@@ -162,16 +183,23 @@ def output_dispatch(out, ctx):
     ``last_hidden_state`` (patch-level) and ``pooler_output`` (merger-reduced)
     are shipped — the latter uses splits rescaled by the merger factor.
 
-    After the reverse all_to_all, features are laid out in the same dst-sorted
-    order we used on the way out. Undo that permutation so the LLM's
-    ``masked_scatter`` sees frames in the original local order.
+    After the reverse all_to_all, features are laid out on the originating
+    ``cp_rank == 0`` worker only (since cp_rank > 0 was a pure receiver in the
+    forward dispatch). We then broadcast within the cp group via an
+    autograd-aware all_reduce so every cp rank can run ``masked_scatter``
+    before the SP layer slices the seq.
+
+    Source ranks (cp_rank == 0) finally undo the dst-sorted permutation so the
+    LLM's ``masked_scatter`` sees frames in the original local order.
     """
     in_splits = ctx["input_splits"]
     out_splits = ctx["output_splits"]
     group = ctx["group"]
+    cp_group: Optional[dist.ProcessGroup] = ctx["cp_group"]
     send_order: torch.Tensor = ctx["send_order"]
     patches_per_local: torch.Tensor = ctx["patches_per_local"]
-    device = patches_per_local.device
+    is_source: bool = ctx["is_source"]
+    device = out.last_hidden_state.device
 
     # last_hidden_state: same scale as patches, use splits as-is.
     last_hidden = all_to_all_single_autograd(
@@ -182,10 +210,17 @@ def output_dispatch(out, ctx):
     )
 
     # pooler_output: patches // spatial_merge_size**2, infer scale from tensor.
+    # Source ranks (cp_rank == 0) always have real patches; non-source ranks
+    # have zero-sized inputs and outputs everywhere, so any ``scale`` works
+    # (all the all_to_all splits below are 0). The cp broadcast at the bottom
+    # restores the real shape.
     n_tokens = out.pooler_output.shape[0]
     n_patches = sum(in_splits)
-    assert n_patches % n_tokens == 0, f"pooler_output tokens ({n_tokens}) doesn't divide patch total ({n_patches})"
-    scale = n_patches // n_tokens
+    if n_tokens > 0 and n_patches > 0:
+        assert n_patches % n_tokens == 0, f"pooler_output tokens ({n_tokens}) doesn't divide patch total ({n_patches})"
+        scale = n_patches // n_tokens
+    else:
+        scale = 1
     pooler_in = [s // scale for s in in_splits]
     pooler_out = [s // scale for s in out_splits]
 
@@ -196,9 +231,9 @@ def output_dispatch(out, ctx):
         group=group,
     )
 
-    # ---- unpermute back to local-original frame order ----
+    # ---- unpermute back to local-original frame order (source ranks only) ----
     n_local = send_order.numel()
-    if n_local > 0:
+    if is_source and n_local > 0:
         # Inverse permutation on frame index.
         inv_order = torch.empty_like(send_order)
         inv_order[send_order] = torch.arange(n_local, device=device)
@@ -210,17 +245,49 @@ def output_dispatch(out, ctx):
         full_perm = torch.cat(
             [torch.arange(starts_full[i], starts_full[i + 1], device=device) for i in inv_order.tolist()]
         )
-        out.last_hidden_state = last_hidden[full_perm]
+        last_hidden = last_hidden[full_perm]
 
         # pooler tokens: (T*H*W // scale) per frame
-        per_pooler = patches_per_local[send_order] // scale
+        per_pooler = patches_per_local[send_order] // max(scale, 1)
         starts_pool = torch.cat([torch.zeros(1, dtype=torch.long, device=device), per_pooler.cumsum(0)])
         pool_perm = torch.cat(
             [torch.arange(starts_pool[i], starts_pool[i + 1], device=device) for i in inv_order.tolist()]
         )
-        out.pooler_output = pooler[pool_perm]
-    else:
-        out.last_hidden_state = last_hidden
-        out.pooler_output = pooler
+        pooler = pooler[pool_perm]
 
+    # ---- CP broadcast: source rank holds the real features, others hold
+    # zero-sized tensors. We need every cp rank to end up with an identical
+    # full-shape copy so ``masked_scatter`` works before SP slicing.
+    if cp_group is not None and dist.get_world_size(group=cp_group) > 1:
+        cp_size = dist.get_world_size(group=cp_group)
+
+        # Agree on the canonical shape across the cp group (source rank knows
+        # it; others have shape[0]==0). We pick the max along dim 0.
+        local_shape = torch.tensor([last_hidden.shape[0], pooler.shape[0]], dtype=torch.long, device=device)
+        max_shape = local_shape.clone()
+        dist.all_reduce(max_shape, op=dist.ReduceOp.MAX, group=cp_group)
+        n_last, n_pool = int(max_shape[0].item()), int(max_shape[1].item())
+
+        hidden_dim = last_hidden.shape[1] if last_hidden.shape[0] > 0 else None
+        pooler_dim = pooler.shape[1] if pooler.shape[0] > 0 else None
+        # Hidden_dim must agree across cp ranks: gather it via max as well.
+        dim_tensor = torch.tensor([hidden_dim or 0, pooler_dim or 0], dtype=torch.long, device=device)
+        dist.all_reduce(dim_tensor, op=dist.ReduceOp.MAX, group=cp_group)
+        hidden_dim = int(dim_tensor[0].item())
+        pooler_dim = int(dim_tensor[1].item())
+
+        # Pad non-source ranks up to (n_last, hidden_dim) / (n_pool, pooler_dim)
+        # with zeros so all_reduce(SUM) reproduces the source values.
+        if last_hidden.shape[0] != n_last:
+            last_hidden = last_hidden.new_zeros((n_last, hidden_dim))
+        if pooler.shape[0] != n_pool:
+            pooler = pooler.new_zeros((n_pool, pooler_dim))
+
+        # autograd-aware: backward through all_reduce(SUM) is itself a SUM,
+        # which on the source rank receives the summed grads from all cp ranks.
+        last_hidden = all_reduce(last_hidden, reduceOp="sum", group=cp_group)
+        pooler = all_reduce(pooler, reduceOp="sum", group=cp_group)
+
+    out.last_hidden_state = last_hidden
+    out.pooler_output = pooler
     return out

--- a/src/lmms_engine/parallel/process_group_manager.py
+++ b/src/lmms_engine/parallel/process_group_manager.py
@@ -86,6 +86,14 @@ class ProcessGroupManager:
         self.dp_group = dist.new_subgroups_by_enumeration(
             [self.grid[:, p, c, t].tolist() for p in range(pp_size) for c in range(cp_size) for t in range(tp_size)]
         )[0]
+        # Flatten dp & cp axes into a single group. Used by ViT frame parallel
+        # so frames can be balanced across both data-parallel and seq-parallel
+        # ranks at once (ViT inputs are duplicated across cp ranks since the
+        # dataloader only shards on dp, so we must split frames at the
+        # (dp x cp) granularity to actually reduce ViT memory under SP).
+        self.dp_cp_group = dist.new_subgroups_by_enumeration(
+            [self.grid[:, p, :, t].flatten().tolist() for p in range(pp_size) for t in range(tp_size)]
+        )[0]
 
         if ep_size > 1:
             self.ep_grid = torch.arange(dp_size).view(dp_shard_mod_ep, dp_shard_in_ep)
@@ -109,6 +117,8 @@ class ProcessGroupManager:
         self.cp_world_size = dist.get_world_size(group=self.cp_group)
         self.cp_first_rank = self.cp_group_ids[0]
         self.cp_last_rank = self.cp_group_ids[-1]
+
+        self.dp_cp_world_size = dist.get_world_size(group=self.dp_cp_group)
 
         self.pp_world_size = dist.get_world_size(group=self.pp_group)
         self.pp_first_rank = self.pp_group_ids[0]


### PR DESCRIPTION
## Summary

Adds sequence parallel (SP) support for Qwen3.5's hybrid attention (full-attn + linear-attn) and integrates it with the existing ViT frame parallelism so SP also reduces ViT memory.

## Changes

### SP for the LM (commit 4a443fb)
- `qwen3_5_ops.py`:
  - `model_forward`: pad packed seq to a multiple of `sp_size` via `ulysses_pad` (qwen3_vl style) and append the pad span as its own sample in `cu_seq_lens` so linear-attn / causal-conv don't leak pad into real samples.
  - `attn_forward` (full-attn): Ulysses all-to-all + KV repeat to satisfy `sp_size`. Gate stays seq-sharded.
  - `linear_attn_forward`: under SP, build `FLACPContext` from the global `cu_seq_lens` and use fla's CP-aware `causal_conv1d_cp` + `chunk_gated_delta_rule(cp_context=...)`. No more hand-rolled halo logic.
- `monkey_patch.py`: hook `patch_vlm_for_ulysses_input_slicing` on `Qwen3_5TextModel` when `use_rmpad=True`.

### ViT frame parallel × SP (commit 14a4a0e)
Previously `vit_frame_parallel` ran on `dp_group`, so under SP the same frames were duplicated across cp ranks and ViT memory didn't shrink.

- `process_group_manager.py`: new `dp_cp_group` flattening dp×cp into one subgroup (+ `dp_cp_world_size`).
- `qwen3_5_vit_ops.py`:
  - `input_dispatch(group=dp_cp_group, cp_group=cp_group)`: only `cp_rank == 0` contributes frames to the LPT pool (cp ranks within the same dp_rank hold duplicated dataloader input). LPT balances dedup'd frames across `dp × cp` workers, so each rank handles `total_frames / (dp·cp)` frames.
  - `output_dispatch`: reverse all_to_all routes features back to `cp_rank == 0`, then an autograd-aware `all_reduce(SUM)` inside `cp_group` (with non-source ranks holding zero-padded tensors) broadcasts the features so every cp rank has a full copy. This is needed because `masked_scatter` happens *before* the SP layer slices the seq, so every rank's inputs_embeds still needs the full visual features.
- `monkey_patch.py`: `apply_vit_frame_parallel_to_qwen3_5` now uses `dp_cp_group` and passes `cp_group` through.

## Test

Smoke-tested locally with SP enabled (cp_size > 1).