### PR TITLE
feat(profiler): CUDA memory snapshot with auto-dump on OOM

### DIFF
--- a/src/lmms_engine/train/config.py
+++ b/src/lmms_engine/train/config.py
@@ -18,6 +18,11 @@ class TrainingArguments(transformers.TrainingArguments):
     print_batch_input_steps: Optional[int] = -1
     enable_profiler: Optional[bool] = False
     profiler_config: Optional[Dict[str, Any]] = None
+    # CUDA memory snapshot profiler (separate from StepProfiler).
+    # When enabled, records every alloc/free event with Python stack traces
+    # and auto-dumps a .pickle on CUDA OOM. View at https://pytorch.org/memory_viz
+    enable_memory_snapshot: Optional[bool] = False
+    memory_snapshot_config: Optional[Dict[str, Any]] = None
 
     # Parallelism
     ep_degree: Optional[int] = 1

--- a/src/lmms_engine/train/fsdp2/fsdp2_trainer.py
+++ b/src/lmms_engine/train/fsdp2/fsdp2_trainer.py
@@ -35,7 +35,7 @@ from lmms_engine.utils.fsdp2_utils import (
     get_cosine_schedule_with_warmup,
     get_wsd_schedule_with_warmup,
 )
-from lmms_engine.utils.profiler import StepProfiler
+from lmms_engine.utils.profiler import MemorySnapshotProfiler, StepProfiler
 from lmms_engine.utils.tracking import Tracking
 
 DatasetType = Union[Dataset, IterableDataset]
@@ -72,6 +72,13 @@ class FSDP2SFTTrainer:
             directory=self.profiler_dir,
             profiler_config=self.profiler_config,
             rank=dist.get_rank(),
+        )
+        # CUDA memory snapshot profiler (auto-dumps on OOM)
+        self.memory_snapshot_profiler = MemorySnapshotProfiler(
+            enable=getattr(self.args, "enable_memory_snapshot", False),
+            directory=os.path.join(self.args.output_dir, "memory_snapshot"),
+            rank=dist.get_rank(),
+            memory_snapshot_config=getattr(self.args, "memory_snapshot_config", None),
         )
         self.accumulated_grad_steps = 0
 
@@ -337,6 +344,7 @@ class FSDP2SFTTrainer:
 
         logger.info(f"Training with {self.args.num_train_epochs} epochs with {self.total_steps} steps")
         self.step_profiler.start()
+        self.memory_snapshot_profiler.start()
 
         curr_epoch = start_epoch
 
@@ -357,6 +365,7 @@ class FSDP2SFTTrainer:
                     break
                 # send batch to device
                 batch = send_to_device(batch, self.fsdp2_model.device)
+                self.memory_snapshot_profiler.step(self.global_step)
                 start_time = time.perf_counter()
                 train_metrics = self.training_step(batch)
                 self.step_profiler.step()
@@ -418,6 +427,7 @@ class FSDP2SFTTrainer:
             curr_epoch += 1
 
         pbar.close()
+        self.memory_snapshot_profiler.stop_and_save(reason="train_end")
         # Save the final checkpoint
         output_dir = os.path.join(self.args.output_dir, f"checkpoint-{self.global_step}")
         self.save_checkpoints(output_dir, self.global_step, total_limit=self.args.save_total_limit)

--- a/src/lmms_engine/utils/profiler.py
+++ b/src/lmms_engine/utils/profiler.py
@@ -82,3 +82,100 @@ class StepProfiler:
         if self.check():
             logger.info(f"[Profiler] Trace stopped for rank {self.rank}")
             self.skip_prof = True
+
+
+class MemorySnapshotProfiler:
+    """CUDA memory snapshot profiler with automatic OOM capture.
+
+    When enabled, records every CUDA alloc/free event (with Python stack
+    traces) into an in-memory ring buffer via
+    ``torch.cuda.memory._record_memory_history``. On a ``CUDA OOM``, an
+    out-of-memory observer dumps the buffer to a ``.pickle`` file that can
+    be loaded into https://pytorch.org/memory_viz for visualization.
+
+    Independent of ``StepProfiler`` — both can be enabled together.
+
+    Config keys (under ``memory_snapshot_config``):
+        - ``max_entries`` (int, default 100000): ring buffer size. One alloc
+          or free event = one entry. 100k covers ~a few training steps.
+        - ``stop_step`` (int, optional): if set, stop recording and dump a
+          final snapshot at this global step (useful for inspecting steady
+          state without OOM).
+    """
+
+    def __init__(
+        self,
+        enable: bool,
+        directory: str,
+        rank: int = 0,
+        memory_snapshot_config: Optional[Dict[str, Any]] = None,
+    ):
+        self.enable = enable and torch.cuda.is_available()
+        self.rank = rank
+        self.directory = directory
+        self.config = memory_snapshot_config or {}
+        self.max_entries = int(self.config.get("max_entries", 100000))
+        self.stop_step = self.config.get("stop_step", None)
+        self.started = False
+        self.stopped = False
+
+    def _dump(self, filename: str):
+        if not self.enable or self.stopped:
+            return
+        os.makedirs(self.directory, exist_ok=True)
+        path = os.path.join(self.directory, filename)
+        try:
+            torch.cuda.memory._dump_snapshot(path)
+            logger.info(f"[MemSnapshot] dumped snapshot to {path} (rank {self.rank})")
+        except Exception as e:
+            logger.error(f"[MemSnapshot] failed to dump snapshot: {e}")
+
+    def _oom_observer(self, device, alloc, device_alloc, device_free):
+        # Called by PyTorch BEFORE raising CUDA OOM. Dump current snapshot.
+        logger.error(
+            f"[MemSnapshot] CUDA OOM on rank {self.rank} device {device}: "
+            f"attempted to alloc {alloc} bytes "
+            f"(device_alloc={device_alloc}, device_free={device_free})"
+        )
+        self._dump(f"oom_rank{self.rank}.pickle")
+        # Mark stopped so we don't try to dump again on re-raise paths.
+        self.stopped = True
+
+    def start(self):
+        if not self.enable or self.started:
+            return
+        os.makedirs(self.directory, exist_ok=True)
+        torch.cuda.memory._record_memory_history(max_entries=self.max_entries)
+        try:
+            torch._C._cuda_attach_out_of_memory_observer(self._oom_observer)
+        except AttributeError:
+            logger.warning(
+                "[MemSnapshot] OOM observer API not available in this torch version; "
+                "snapshot will only dump on explicit stop_and_save()."
+            )
+        self.started = True
+        logger.info(
+            f"[MemSnapshot] recording started on rank {self.rank} "
+            f"(max_entries={self.max_entries}, dir={self.directory})"
+        )
+
+    def step(self, global_step: int):
+        """Mark step boundary in the snapshot timeline; optionally auto-stop."""
+        if not self.enable or self.stopped:
+            return
+        # NVTX marker → shows up as a vertical line in memory_viz timeline.
+        torch.cuda.nvtx.range_push(f"step_{global_step}")
+        torch.cuda.nvtx.range_pop()
+        if self.stop_step is not None and global_step >= self.stop_step:
+            self.stop_and_save(reason="stop_step")
+
+    def stop_and_save(self, reason: str = "manual"):
+        if not self.enable or self.stopped:
+            return
+        self._dump(f"snapshot_{reason}_rank{self.rank}.pickle")
+        try:
+            torch.cuda.memory._record_memory_history(enabled=None)
+        except Exception:
+            pass
+        self.stopped = True
+        logger.info(f"[MemSnapshot] recording stopped (reason={reason}, rank {self.rank})")


### PR DESCRIPTION
## What

Adds `MemorySnapshotProfiler` alongside the existing `StepProfiler`. Records every CUDA alloc/free with Python stack traces and auto-dumps a `.pickle` snapshot **before** CUDA OOM is raised — viewable at https://pytorch.org/memory_viz for tensor-level peak attribution.

## Why

`StepProfiler` produces chrome traces good for kernel timing, but not for finding which tensors are alive at OOM and where they were allocated. Memory snapshots give that directly.

## Usage

```yaml
trainer_args:
  enable_memory_snapshot: true
  memory_snapshot_config:
    max_entries: 100000   # ring buffer size
    stop_step: 10         # optional, dump and stop at this step
```

## Behavior

- **On OOM**: each rank dumps `{output_dir}/memory_snapshot/oom_rank{N}.pickle` via PyTorch's OOM observer (`torch._C._cuda_attach_out_of_memory_observer`).
- **At `stop_step` (if set)**: dumps `snapshot_stop_step_rank{N}.pickle` and stops recording.
- **At normal train end**: dumps `snapshot_train_end_rank{N}.pickle`.
- **NVTX markers `step_{N}`** emitted each step → memory_viz timeline aligns to `global_step`.
- **Disabled (default)**: zero overhead, all methods early-return.
- **Independent of `StepProfiler`**: both can be enabled simultaneously.

## Files

- `src/lmms_engine/utils/profiler.py`: new `MemorySnapshotProfiler` class
- `src/lmms_engine/train/config.py`: `enable_memory_snapshot`, `memory_snapshot_config`
- `src/lmms_engine/train/fsdp2/fsdp2_trainer.py`: instantiate + `start()` + per-step `step()` + final `stop_and_save()`