### PR TITLE
feat: add HSDP (Hybrid Sharded Data Parallel) support

### DIFF
--- a/docs/user_guide/hsdp.md
+++ b/docs/user_guide/hsdp.md
@@ -1,0 +1,103 @@
+# HSDP (Hybrid Sharded Data Parallel)
+
+## What it does
+
+By default, FSDP2 in this repo shards model parameters across **all** ranks in
+the world. Every forward pass triggers an all-gather over the entire world to
+reassemble parameters, and every backward pass triggers a reduce-scatter over
+the entire world to average gradients.
+
+When training spans multiple nodes, those collectives have to traverse the
+inter-node fabric (InfiniBand / RoCE / etc.), which is typically much slower
+than the intra-node NVLink/NVSwitch.
+
+HSDP splits the world into **shard groups** of a fixed size. Inside a shard
+group, parameters are sharded as usual (cheap intra-node collectives). Across
+shard groups, parameters are **replicated** — only the per-step gradient
+reduce-scatter has to cross the slow link.
+
+The typical mapping is one shard group per node: parameter all-gather stays on
+NVLink, only gradient all-reduce crosses the inter-node link.
+
+## Configuration
+
+Set `hsdp_shard_size` inside `fsdp_config`:
+
+```yaml
+trainer_args:
+  fsdp2: true
+  fsdp_config:
+    transformer_layer_cls_to_wrap: ["Qwen3VLTextDecoderLayer"]
+    reshard_after_forward: true
+    hsdp_shard_size: 8   # 8 GPUs per shard group
+```
+
+Semantics of `hsdp_shard_size`:
+
+| Value | Meaning |
+|---|---|
+| `0` / unset | HSDP disabled. Default full-world FSDP (current behavior). |
+| `1` | Rejected — would be pure DDP, which this trainer does not target. |
+| `> 1` | Enabled. Each shard group has this many ranks; the world is split into `world_size / hsdp_shard_size` replicate groups. |
+
+Constraints:
+
+- `world_size` must be divisible by `hsdp_shard_size`.
+- Special case `hsdp_shard_size == world_size` is **equivalent to plain FSDP**
+  (one shard group, no replicate axis); prefer leaving it unset in that case.
+
+## When to enable
+
+HSDP is a **communication / memory trade-off**:
+
+| `hsdp_shard_size` | Per-GPU parameter memory | Cross-group communication |
+|---|---|---|
+| small | larger (fewer shards) | less |
+| large | smaller (more shards) | more |
+
+Rules of thumb:
+
+- **Multi-node, model fits per node** → set `hsdp_shard_size = ranks_per_node`.
+  This is the headline HSDP win.
+- **Single-node training** → don't enable HSDP. There's no slow link to avoid;
+  full-world FSDP already keeps everything on NVLink.
+- **Model does NOT fit per node** → keep HSDP disabled (or shard across
+  multiple nodes via a larger `hsdp_shard_size`). HSDP cannot make a model fit
+  that plain FSDP couldn't.
+
+## Limitations (current implementation)
+
+The first version supports HSDP only on the default FSDP2 path. The following
+combinations are explicitly rejected with an assertion:
+
+- **Tensor / Context / Expert parallel** (`tp_degree > 1`, `sp_ulysses_degree
+  > 1`, `ep_degree > 1`): the per-model `parallelize` path does not yet plumb
+  the 2D mesh through. Use `hsdp_shard_size = 0` with those.
+- **EP**: same reason; not supported in this version.
+
+The checkpoint merger (`python -m lmms_engine.merger`) already handles
+multi-placement DTensors and is expected to work for HSDP checkpoints, but has
+not been exhaustively validated end-to-end. If you hit issues merging an HSDP
+checkpoint, please open an issue.
+
+## How it works under the hood
+
+When `hsdp_shard_size > 1`, the process group manager builds an independent 2D
+device mesh:
+
+```python
+init_device_mesh(
+    "cuda",
+    (replicate_size, hsdp_shard_size),
+    mesh_dim_names=("hsdp_replicate", "hsdp_shard"),
+)
+```
+
+This mesh is exposed via `pgm.process_group_manager.fsdp_mesh` and passed to
+every `fully_shard` call. FSDP2 dispatches on mesh rank:
+
+- 1D mesh → plain FSDP (full-world shard).
+- 2D mesh → HSDP (replicate on outer axis, shard on inner axis).
+
+Resulting DTensor placements are `(Replicate(), Shard(0))` — replicated across
+shard groups, sharded within each group.

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -9,6 +9,7 @@ Comprehensive guides for using LMMs Engine in various scenarios.
    datasets
    data_prep
    peak_perf
+   hsdp
    vit_frame_parallel
    merge_fsdp
    fsdp2_reduce_dtype

--- a/src/lmms_engine/launch/cli.py
+++ b/src/lmms_engine/launch/cli.py
@@ -88,12 +88,15 @@ def create_train_task(config):
             init_method=f"env://",
             timeout=datetime.timedelta(seconds=ddp_timeout),
         )
+    fsdp_config = trainer_args.get("fsdp_config", {}) or {}
+    hsdp_shard_size = fsdp_config.get("hsdp_shard_size", 0) or 0
     setup_process_group_manager(
         tp_size=tp_degree,
         cp_size=sp_degree,
         pp_size=1,
         dp_size=dp_size,
         ep_size=ep_degree,
+        hsdp_shard_size=hsdp_shard_size,
     )
 
     trainer_args = config.pop("trainer_args")

--- a/src/lmms_engine/launch/config/default_config.yaml
+++ b/src/lmms_engine/launch/config/default_config.yaml
@@ -111,6 +111,11 @@ trainer_args:
     transformer_layer_cls_to_wrap:
     - Qwen2_5_VLDecoderLayer
     reshard_after_forward: false
+    # HSDP (Hybrid Sharded Data Parallel): shard params within groups of
+    # ``hsdp_shard_size`` ranks, replicate across groups.
+    #   0 / unset -> disabled (default full-world FSDP)
+    #   >1        -> enabled (e.g. 8 = shard within each 8-GPU node)
+    hsdp_shard_size: 0
   fsdp_transformer_layer_cls_to_wrap: null
   accelerator_config:
     split_batches: false

--- a/src/lmms_engine/parallel/process_group_manager.py
+++ b/src/lmms_engine/parallel/process_group_manager.py
@@ -20,7 +20,7 @@ from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
 
 class ProcessGroupManager:
-    def __init__(self, tp_size, cp_size, pp_size, dp_size, ep_size=1):
+    def __init__(self, tp_size, cp_size, pp_size, dp_size, ep_size=1, hsdp_shard_size=0):
         self.global_rank = dist.get_rank()
         self.world_size = dist.get_world_size()
         self.local_rank = int(os.environ.get("LOCAL_RANK", self.global_rank % self.world_size))
@@ -32,6 +32,26 @@ class ProcessGroupManager:
         assert pp_size == 1, "PP size must be 1 for now"
         if ep_size > 1:
             assert ep_size % (cp_size * tp_size) == 0 and (dp_size * cp_size * tp_size) % ep_size == 0
+
+        # HSDP (Hybrid Sharded Data Parallel): shard params within groups of
+        # ``hsdp_shard_size`` ranks, replicate params across groups.
+        #   - hsdp_shard_size = 0 / None  -> disabled (default full-world FSDP)
+        #   - hsdp_shard_size > 1         -> enabled
+        #   - hsdp_shard_size = 1         -> rejected (would be pure DDP)
+        hsdp_shard_size = hsdp_shard_size or 0
+        if hsdp_shard_size == 1:
+            raise ValueError(
+                "hsdp_shard_size=1 means pure DDP, which is not supported. "
+                "Use 0 (or omit the field) to disable HSDP, or >1 to enable it."
+            )
+        self.hsdp_shard_size = hsdp_shard_size
+        self.enable_hsdp = hsdp_shard_size > 1
+        if self.enable_hsdp:
+            assert ep_size == 1, "HSDP + EP is not supported in v1"
+            fsdp_total = dp_size * cp_size
+            assert fsdp_total % hsdp_shard_size == 0, (
+                f"dp_size * cp_size ({fsdp_total}) must be divisible by " f"hsdp_shard_size ({hsdp_shard_size})"
+            )
 
         self.tp_size = tp_size
         self.cp_size = cp_size
@@ -64,6 +84,20 @@ class ProcessGroupManager:
         else:
             self.device_mesh["dp", "cp"]._flatten(mesh_dim_name="fsdp")
             self.ep_world_size = 1
+
+        # Build an independent 2D mesh for HSDP. We do NOT touch the existing
+        # ``device_mesh["fsdp"]`` flatten so non-HSDP code paths keep working.
+        # ``fsdp_mesh`` (property) is the single entry point that callers
+        # should use when constructing ``fully_shard`` kwargs.
+        self.hsdp_mesh = None
+        if self.enable_hsdp:
+            fsdp_total = dp_size * cp_size
+            replicate_size = fsdp_total // self.hsdp_shard_size
+            self.hsdp_mesh = init_device_mesh(
+                "cuda",
+                (replicate_size, self.hsdp_shard_size),
+                mesh_dim_names=("hsdp_replicate", "hsdp_shard"),
+            )
 
         self.grid = torch.arange(self.world_size).view(
             dp_size, pp_size, cp_size, tp_size
@@ -154,7 +188,21 @@ class ProcessGroupManager:
     def enable_parallel(self):
         return self.enable_tp or self.enable_pp or self.enable_ep
 
+    @property
+    def fsdp_mesh(self):
+        """Mesh to pass to ``fully_shard``.
 
-def setup_process_group_manager(tp_size, cp_size, pp_size, dp_size, ep_size=1):
+        Returns a 2D mesh (replicate, shard) when HSDP is enabled, otherwise
+        the existing 1D ``device_mesh["fsdp"]``. FSDP2 dispatches on the mesh
+        rank: 1D -> plain FSDP, 2D -> HSDP automatically.
+        """
+        if self.enable_hsdp:
+            return self.hsdp_mesh
+        return self.device_mesh["fsdp"]
+
+
+def setup_process_group_manager(tp_size, cp_size, pp_size, dp_size, ep_size=1, hsdp_shard_size=0):
     global process_group_manager
-    process_group_manager = ProcessGroupManager(tp_size, cp_size, pp_size, dp_size, ep_size)
+    process_group_manager = ProcessGroupManager(
+        tp_size, cp_size, pp_size, dp_size, ep_size, hsdp_shard_size=hsdp_shard_size
+    )

--- a/src/lmms_engine/train/fsdp2/fsdp2_trainer.py
+++ b/src/lmms_engine/train/fsdp2/fsdp2_trainer.py
@@ -136,6 +136,10 @@ class FSDP2SFTTrainer:
     def prepare_model(self):
         model_type = getattr(self.model.config, "model_type", None)
         if model_type in MODEL_TO_PARALLEL_METHOD and pgm.process_group_manager.enable_parallel:
+            assert not pgm.process_group_manager.enable_hsdp, (
+                "HSDP is not yet supported with the parallelize path "
+                "(TP/CP/EP). Set hsdp_shard_size=0 or disable parallelism."
+            )
             apply_parallelize(self.model, model_type, self.args)
             self.fsdp2_model = self.model
             return
@@ -159,6 +163,7 @@ class FSDP2SFTTrainer:
         fsdp_kwargs = {
             "reshard_after_forward": getattr(self.args, "fsdp_config", {}).get("reshard_after_forward", True),
             "mp_policy": mp_policy,
+            "mesh": pgm.process_group_manager.fsdp_mesh,
         }
 
         transformer_cls_names_to_wrap = self.args.fsdp_config.get("transformer_layer_cls_to_wrap", None)

--- a/test/train/qwen3_vl/test_qwen3_vl.py
+++ b/test/train/qwen3_vl/test_qwen3_vl.py
@@ -66,6 +66,42 @@ class TestQwen3_VL(TestCase):
         if result.stderr:
             print("Training stderr:", result.stderr)
 
+    @with_temp_dir
+    @with_multi_gpu_training
+    def test_text_train_fsdp2_hsdp(self, temp_dir, nproc_per_node):
+        """Test Qwen3-VL training with FSDP2 + HSDP (hsdp_shard_size=2)."""
+
+        if nproc_per_node < 4:
+            self.skipTest(
+                f"HSDP test requires >=4 GPUs (got {nproc_per_node}); "
+                "with fewer ranks hsdp_shard_size=2 degenerates."
+            )
+
+        # Path to the training script
+        script_path = os.path.join(os.path.dirname(__file__), "train_qwen3_vl_hsdp.py")
+
+        # Launch training using torchrun
+        result = launch_torchrun_training(
+            script_path=script_path,
+            output_dir=temp_dir,
+            nproc_per_node=nproc_per_node,
+            timeout=600,  # 10 minutes timeout
+        )
+
+        # Assert training completed successfully
+        self.assertIsNotNone(result, "Training process should not be None")
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"Training failed with return code {result.returncode}",
+        )
+
+        # Print training output for debugging
+        if result.stdout:
+            print("Training stdout:", result.stdout)
+        if result.stderr:
+            print("Training stderr:", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/train/qwen3_vl/train_qwen3_vl_hsdp.py
+++ b/test/train/qwen3_vl/train_qwen3_vl_hsdp.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Training script for Qwen3-VL model with HSDP (Hybrid Sharded Data Parallel).
+On a 2-GPU box, hsdp_shard_size=2 would degenerate to plain FSDP, so this
+script targets >=4 GPU tests with hsdp_shard_size=2 (2 shard groups of 2
+ranks each).
+"""
+
+import argparse
+import os
+import sys
+
+from lmms_engine.launch.cli import create_train_task
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train Qwen3-VL model")
+    parser.add_argument("--output_dir", type=str, required=True, help="Output directory for training")
+    parser.add_argument("--nproc_per_node", type=int, default=1, help="Number of processes per node")
+    parser.add_argument("--nnodes", type=int, default=1, help="Number of nodes")
+    parser.add_argument("--node_rank", type=int, default=0, help="Rank of this node")
+    parser.add_argument("--master_addr", type=str, default="127.0.0.1", help="Master address")
+    parser.add_argument("--master_port", type=str, default="8000", help="Master port")
+
+    args = parser.parse_args()
+
+    # Training configuration
+    cfg = {
+        "trainer_type": "fsdp2_trainer",
+        "dataset_config": {
+            "dataset_type": "qwen3_vl_iterable",
+            "dataset_format": "yaml",
+            "datasets": [
+                {
+                    "path": "data/lmms_engine_test/text_example/open_thoughts_5k.parquet",
+                    "data_folder": "",
+                    "data_type": "parquet",
+                }
+            ],
+            "processor_config": {
+                "processor_name": "Qwen/Qwen3-VL-4B-Instruct",
+                "processor_type": "qwen3_vl",
+            },
+            "packing": False,
+            "video_backend": "qwen_vl_utils",
+        },
+        "model_config": {
+            "load_from_pretrained_path": "Qwen/Qwen3-VL-4B-Instruct",
+            "attn_implementation": "flash_attention_2",
+        },
+        "trainer_args": {
+            "per_device_train_batch_size": 1,
+            "gradient_checkpointing": True,
+            "num_train_epochs": 1,
+            "max_steps": 10,
+            "report_to": "none",
+            "output_dir": args.output_dir,
+            "warmup_ratio": 0.0,
+            "eval_strategy": "no",
+            "dataloader_num_workers": 8,
+            "bf16": True,
+            "lr_scheduler_type": "cosine",
+            "use_liger_kernel": True,
+            "use_rmpad": True,
+            "fsdp2": True,
+            "group_by_length": True,
+            "fsdp_config": {
+                "transformer_layer_cls_to_wrap": ["Qwen3VLTextDecoderLayer"],
+                "reshard_after_forward": False,
+                "hsdp_shard_size": 2,
+            },
+            "sp_ulysses_degree": 1,
+            "print_batch_input_steps": -1,
+        },
+    }
+
+    # Create and run training task
+    train_task = create_train_task(cfg)
+    train_task.build()
+    train_task.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds opt-in HSDP for the default FSDP2 path. With HSDP, parameters are sharded within fixed-size rank groups and **replicated** across groups, so the expensive all-gather collectives stay inside a fast domain (typically a node's NVLink) and only the gradient reduce crosses the slow inter-node link.

## Configuration

```yaml
trainer_args:
  fsdp2: true
  fsdp_config:
    hsdp_shard_size: 8   # 8 GPUs per shard group
```

| Value | Meaning |
|---|---|
| \`0\` / unset | HSDP disabled, full-world FSDP (current behavior) |
| \`1\` | Rejected (would be pure DDP) |
| \`>1\` | Enabled, world split into \`world_size / hsdp_shard_size\` replicate groups |

## Implementation

- \`ProcessGroupManager\` accepts \`hsdp_shard_size\` and, when enabled, builds an independent 2D mesh \`(hsdp_replicate, hsdp_shard)\`.
- New property \`pgm.fsdp_mesh\` returns the 2D HSDP mesh when enabled, otherwise the existing 1D \`device_mesh[\"fsdp\"]\`. FSDP2 dispatches on mesh rank: 1D → plain FSDP, 2D → HSDP automatically.
- \`fsdp2_trainer.prepare_model\` passes \`fsdp_mesh\` to \`fully_shard\` and asserts HSDP is not combined with the parallelize path.
- CLI reads \`hsdp_shard_size\` from \`trainer_args.fsdp_config\` and threads it to \`setup_process_group_manager\`.

## Out of scope (v1)

Guarded by asserts:
- Per-model \`parallelize\` path (TP / CP / EP) — would need \`device_mesh[\"fsdp\"]\` references in \`parallel/*/parallelize.py\` to migrate to \`pgm.fsdp_mesh\`.
- EP combined with HSDP.

The checkpoint merger already handles multi-placement DTensors (originally for EP); HSDP's \`(Replicate(), Shard(0))\` placements go through the same code path but have not been exhaustively validated end-to-end.

## Test

- New: \`test/train/qwen3_vl/test_text_train_fsdp2_hsdp\` (\`hsdp_shard_size=2\`, requires ≥4 GPUs; skips on smaller clusters).
- Verified: \`cicd/run_traincicd.sh --model-name qwen3_vl --gpu-count 4\` — all 3 tests pass (fsdp2 / fsdp2_ema / fsdp2_hsdp).
- Loss curves with and without HSDP confirmed aligned by the reviewer.

## Docs

- New: \`docs/user_guide/hsdp.md\` (semantics, configuration, when to enable, limitations).
- Added to \`docs/user_guide/index.rst\` toctree.
- \`default_config.yaml\` exposes \`hsdp_shard_size: 0\` with an inline comment.