### PR TITLE
perf(fsdp2): reduce per-step host/comm overhead

### DIFF
--- a/src/lmms_engine/train/fsdp2/fsdp2_trainer.py
+++ b/src/lmms_engine/train/fsdp2/fsdp2_trainer.py
@@ -418,14 +418,13 @@ class FSDP2SFTTrainer:
                     )
                     self.compute_tracker.accumulate_flops(raw_flops)
                     device = self.fsdp2_model.device
-                    flops_tensor = torch.tensor(flops, device=device)
                     sp_size = pgm.process_group_manager.cp_world_size
                     tp_size = pgm.process_group_manager.tp_world_size
                     parallel_size = sp_size * tp_size
 
                     # Calculate training metrics (MFU, token stats, throughput)
                     perf_metrics, self.total_tokens = self.calculate_training_metrics(
-                        flops_tensor=flops_tensor,
+                        flops=flops,
                         parallel_size=parallel_size,
                         promised_flops=promised_flops,
                         device=device,
@@ -664,7 +663,7 @@ class FSDP2SFTTrainer:
 
     @staticmethod
     def calculate_training_metrics(
-        flops_tensor: torch.Tensor,
+        flops: float,
         parallel_size: int,
         promised_flops: float,
         device: torch.device,
@@ -676,54 +675,61 @@ class FSDP2SFTTrainer:
         """
         Calculate training performance metrics including MFU, token statistics, and throughput.
 
+        Uses a single ``all_gather`` over a 2-element per-rank tensor
+        ``[mfu_local, seq_len_sum_local]`` and reduces (mean/sum/min/max)
+        locally, replacing five independent ``all_reduce`` calls.
+
         Args:
-            flops_tensor: Tensor containing FLOPs count
-            parallel_size: Product of sequence and tensor parallel sizes
-            promised_flops: Promised FLOPs capacity
-            device: Device to perform computations on
-            seq_len: List of sequence lengths per batch
-            total_tokens: Current total token count
-            delta_time: Time taken for the training step
-            world_size: Distributed training world size
+            flops: Per-rank FLOPs count (Python float from ``estimate_flops``).
+            parallel_size: Product of sequence and tensor parallel sizes.
+            promised_flops: Promised FLOPs capacity.
+            device: Device to perform computations on.
+            seq_len: List of sequence lengths per batch (one entry per local sample).
+            total_tokens: Current total token count.
+            delta_time: Time taken for the training step.
+            world_size: Distributed training world size.
 
         Returns:
             tuple: (metrics_dict, updated_total_tokens)
         """
-        metrics = {}
+        # Divide mfu by parallel size because seq_len/flops are estimated
+        # before SP/TP sharding. seq_len comes in as a plain Python list so we
+        # avoid an extra GPU sync and just sum it on the host.
+        mfu_local = flops / parallel_size / promised_flops
+        seq_len_sum_local = float(sum(seq_len))
 
-        # Calculate mfu per rank
-        # Divide by parallel size because seq_len/flops are estimated before SP/TP sharding.
-        mfu = flops_tensor.item() / parallel_size / promised_flops
-        mfu = torch.tensor(mfu, device=device)
-        torch.distributed.all_reduce(mfu, op=torch.distributed.ReduceOp.AVG)
-        mfu = mfu.item()
+        local = torch.tensor([mfu_local, seq_len_sum_local], device=device, dtype=torch.float32)
+        gathered = torch.empty(world_size * 2, device=device, dtype=torch.float32)
+        torch.distributed.all_gather_into_tensor(gathered, local)
+        gathered = gathered.view(world_size, 2)
 
-        # Calculating token stats
-        seq_len = torch.tensor(seq_len, device=device, dtype=torch.float32)
-        # Divide by parallel size to avoid counting replicated SP/TP batches multiple times.
-        total_seq_len = seq_len.sum() / parallel_size
-        torch.distributed.all_reduce(total_seq_len, op=torch.distributed.ReduceOp.SUM)
-        # Avg seq len won't be effected by sp since we perform all reduce
-        # across world size
-        global_seq_len_avg = seq_len.sum()
-        torch.distributed.all_reduce(global_seq_len_avg, op=torch.distributed.ReduceOp.AVG)
-        metrics["perf/global_seq_len_avg"] = global_seq_len_avg.item()
-        global_seq_len_min = seq_len.sum()
-        torch.distributed.all_reduce(global_seq_len_min, op=torch.distributed.ReduceOp.MIN)
-        metrics["perf/global_seq_len_min"] = global_seq_len_min.item()
-        global_seq_len_max = seq_len.sum()
-        torch.distributed.all_reduce(global_seq_len_max, op=torch.distributed.ReduceOp.MAX)
-        metrics["perf/global_seq_len_max"] = global_seq_len_max.item()
+        mfu_all = gathered[:, 0]
+        sl_all = gathered[:, 1]
 
-        metrics["train/mfu"] = round(mfu, 2)
-        total_tokens += total_seq_len.item()
+        # Reduce on-device, then do a single batched .tolist() sync to pull
+        # all five scalars at once.
+        reduced = torch.stack(
+            [
+                mfu_all.mean(),
+                sl_all.sum() / parallel_size,  # total_seq_len (deduped across SP/TP)
+                sl_all.mean(),  # global_seq_len_avg
+                sl_all.amin(),  # global_seq_len_min
+                sl_all.amax(),  # global_seq_len_max
+            ]
+        ).tolist()
+        mfu, total_seq_len, global_seq_len_avg, global_seq_len_min, global_seq_len_max = reduced
 
-        tokens_per_second = total_seq_len.item() / delta_time
+        total_tokens += total_seq_len
+        tokens_per_second = total_seq_len / delta_time
         tokens_per_gpu = tokens_per_second / world_size
 
-        # Log total tokens and total tokens per second
-        metrics["train/total_tokens"] = TrainUtilities.format_tokens(total_tokens)
-        metrics["train/tokens_per_second"] = round(tokens_per_second)
-        metrics["train/tokens_per_gpu"] = round(tokens_per_gpu)
-
+        metrics = {
+            "train/mfu": round(mfu, 2),
+            "perf/global_seq_len_avg": global_seq_len_avg,
+            "perf/global_seq_len_min": global_seq_len_min,
+            "perf/global_seq_len_max": global_seq_len_max,
+            "train/total_tokens": TrainUtilities.format_tokens(total_tokens),
+            "train/tokens_per_second": round(tokens_per_second),
+            "train/tokens_per_gpu": round(tokens_per_gpu),
+        }
         return metrics, total_tokens

--- a/src/lmms_engine/train/fsdp2/fsdp2_trainer.py
+++ b/src/lmms_engine/train/fsdp2/fsdp2_trainer.py
@@ -95,6 +95,16 @@ class FSDP2SFTTrainer:
         # Optional EMA (fully opt-in)
         self.ema = EMAHelper(self.args)
 
+        # send_to_device uses non_blocking=True to overlap H2D with the next
+        # training step. This requires pinned memory; pageable memory falls
+        # back to a synchronous copy and the flag becomes a no-op.
+        if not self.args.dataloader_pin_memory:
+            logger.warning(
+                "send_to_device uses non_blocking=True but dataloader_pin_memory "
+                "is False; H2D copies will fall back to synchronous. Enable "
+                "dataloader_pin_memory for best throughput."
+            )
+
         # Optional Eval Server Backend (only on rank 0)
         self.eval_backend = None
         if dist.get_rank() == 0 and self.args.eval_config is not None and self.args.eval_strategy != "no":
@@ -380,7 +390,7 @@ class FSDP2SFTTrainer:
                     break
                 # send batch to device
                 with self.cuda_event_profiler.record("host_to_device", self.global_step):
-                    batch = send_to_device(batch, self.fsdp2_model.device)
+                    batch = send_to_device(batch, self.fsdp2_model.device, non_blocking=True)
                 self.memory_snapshot_profiler.step(self.global_step)
                 start_time = time.perf_counter()
                 try:


### PR DESCRIPTION
## Summary

Two small follow-ups discussed in #179. Each is one commit, independently revertable.

### 1. `non_blocking=True` for host-to-device

\`send_to_device\` defaulted to \`non_blocking=False\`, so the H2D transfer was synchronous on every step even though the repo already defaults \`dataloader_pin_memory=True\`. Flipping the flag lets the copy overlap the first kernels of the following \`training_step\`.

Adds a one-time warning at trainer init when \`dataloader_pin_memory=False\`, since the flag becomes a no-op on pageable memory (mirrors the existing check in \`train/hf/trainer.py\`).

### 2. Five \`all_reduce\` collectives → one \`all_gather\`

\`calculate_training_metrics\` issued five separate \`all_reduce\` calls (\`AVG\` mfu, \`SUM\` total seq len, \`AVG\`/\`MIN\`/\`MAX\` seq len stats) on scalar tensors. Each one paid full collective latency and forced a \`.item()\` GPU→CPU sync.

Replaced with a single \`all_gather_into_tensor\` over a 2-element per-rank tensor \`[mfu_local, seq_len_sum_local]\`, then mean/sum/min/max are computed locally on the gathered tensor with one batched \`.tolist()\` to pull all five scalars at once.

Also dropped the \`torch.tensor(flops, device=...)\` wrapper at the caller — \`calculate_training_metrics\` now accepts the Python float from \`estimate_flops\` directly, removing one host→device roundtrip.

## Notes

Per-step wins here are small in absolute terms — \`training_metrics\` was already only a few ms — but the changes are pure cleanup with no behavior change. Output metrics are bit-equivalent to before (modulo float32 reduction order, which already varied across ranks).

## Test

Verified via \`cicd/run_traincicd.sh --model-name qwen3_vl --gpu-count 4\` locally; loss curve and reported metric values match main.

## Out of scope

Discussed but deferred:

- Skipping the metrics computation entirely on non-\`logging_steps\` steps (largest potential win, but changes user-visible logging behavior).
- Removing the \`seq_len.detach().cpu().tolist()\` sync inside the metrics block. This would require changing \`flops_counter.estimate_flops\` to accept a tensor; cross-cutting and outside this PR.
- Async-pipelined metrics (compute on step N, log on step N+1).