### PR TITLE
fix(fsdp2): broadcast non-persistent buffers under enable_parallel

### DIFF
--- a/src/lmms_engine/utils/fsdp2_utils.py
+++ b/src/lmms_engine/utils/fsdp2_utils.py
@@ -79,6 +79,12 @@ def fsdp2_load_full_state_dict(model: torch.nn.Module, full_state: dict, device_
                 sharded_tensor = full_tensor
             sharded_sd[param_name] = nn.Parameter(sharded_tensor)
         model.load_state_dict(sharded_sd, assign=True)
+
+        # non-persistent buffers (e.g. rotary inv_freq) are not in `full_state`;
+        # on non-rank-0 they come from `to_empty` and contain uninitialized memory,
+        # which can silently produce NaN in rotary_emb. Broadcast from rank 0 to fix.
+        for name, buf in model.named_buffers():
+            dist.broadcast(buf, src=0)
     else:
         from torch.distributed.checkpoint.state_dict import (
             StateDictOptions,


### PR DESCRIPTION
## Problem

Under `enable_parallel=True` (SP/EP/TP), `fsdp2_load_full_state_dict` loads params from the full state dict but **never touches buffers**. Non-persistent buffers (e.g. `rotary_emb.inv_freq`) are not in the state dict, and non-rank-0 processes start with `model.to_empty(device='cuda')` which returns uninitialized GPU memory — this memory can be any value, including `NaN`.

Result: `rotary_emb(hidden_states, position_ids)` on non-rank-0 ranks silently produces NaN cos/sin, which propagates through attention and blows up the loss.

## Repro

- FSDP2 + `sp_ulysses_degree > 1` (any parallelism that flips `enable_parallel=True`)
- Model has any non-persistent buffer (any rotary embedding module registered via `register_buffer(..., persistent=False)`)
- Symptom: finite inputs, NaN outputs from the rotary_emb module; adding a `.item()` sync sometimes reshuffles allocator state and hides it.

## Fix

Broadcast all buffers from rank 0 after loading the sharded state dict, matching what the non-parallel branch already does (lines 98-100).

## Verification

Trainer smoke: after this patch, non-rank-0 `inv_freq` matches rank 0 exactly, and rotary_emb outputs stay finite through forward.

## Backward compatibility

Additive — no behavior change on `enable_parallel=False` path, and on `enable_parallel=True` the previous behavior only worked by accident when the uninitialized memory happened to be all zeros.