### PR TITLE
feat: add Aero Realtime training support

### DIFF
--- a/examples/aero_realtime/example_config.yaml
+++ b/examples/aero_realtime/example_config.yaml
@@ -1,0 +1,267 @@
+# AeroRealtime Training Configuration
+# Trains the AeroRealtime model on LLaVA-Video-178K data (normal video QA mode).
+#
+# The realtime text stream is conditioned on audio positions only. Video
+# placeholders receive pure vision features, while audio placeholders carry
+# rt_pad / rt_speak / realtime text tokens along the audio timeline.
+#
+# Audio is auto-extracted from video files by the dataset.
+#
+# Override paths at launch time:
+#   model_config.load_from_pretrained_path=/path/to/aero_realtime_init
+#   dataset_config.processor_config.processor_name=/path/to/aero_realtime_init
+#   dataset_config.datasets.0.path=/path/to/parquet
+#   dataset_config.datasets.0.data_folder=/path/to/video/root
+
+trainer_type: fsdp2_trainer
+
+dataset_config:
+  dataset_type: aero_realtime_iterable
+  dataset_format: yaml
+  dataset_path: null
+  processor_config:
+    processor_name: null  # Override: path to aero_realtime_init checkpoint
+    processor_type: aero_realtime
+    extra_kwargs:
+      video_max_pixels: 360448   # ~602*600 — moderate resolution for 4B model
+      video_min_pixels: 28800
+      image_max_pixels: 360448
+      image_min_pixels: 28800
+
+  # Inline dataset configuration — override paths at launch time
+  datasets:
+    - path: null           # Override: path to parquet file
+      data_folder: null    # Override: root directory for video files
+      data_type: parquet
+
+  shuffle: true
+  eval_dataset_path: null
+  object_storage: none
+  bucket_name: null
+
+  # Packing disabled for initial training (video lengths vary)
+  packing: false
+  packing_strategy: first_fit
+  packing_length: 8192
+  filter_overlong: true
+  filter_overlong_workers: 8
+  max_length: null
+
+  # Video sampling: 1 fps for 0-30s videos
+  video_sampling_strategy: fps
+  video_max_pixels: 360448
+  video_max_frames: 64
+  frame_num: 32
+  fps: 1
+  video_backend: qwen_vl_utils
+
+  extra_kwargs: {}
+
+trainer_args:
+  output_dir: ./output/aero_realtime_training
+  overwrite_output_dir: false
+  do_train: true
+  do_eval: false
+  do_predict: false
+  eval_strategy: 'no'
+  prediction_loss_only: false
+
+  # Batch size — start conservative for 4B+ model with video+audio
+  per_device_train_batch_size: 1
+  per_device_eval_batch_size: 1
+  gradient_accumulation_steps: 4
+  eval_accumulation_steps: null
+  eval_delay: 0
+  torch_empty_cache_steps: null
+
+  # Optimizer
+  learning_rate: 1.0e-05
+  weight_decay: 0.0
+  adam_beta1: 0.9
+  adam_beta2: 0.999
+  adam_epsilon: 1.0e-08
+  max_grad_norm: 1.0
+
+  # Training schedule
+  num_train_epochs: 1
+  max_steps: -1
+  lr_scheduler_type: cosine
+  lr_scheduler_kwargs: {}
+  warmup_ratio: 0.03
+  warmup_steps: 0
+
+  # Logging
+  log_level: passive
+  log_level_replica: warning
+  log_on_each_node: true
+  logging_dir: ./output/aero_realtime_training/runs
+  logging_strategy: steps
+  logging_first_step: false
+  logging_steps: 1
+  logging_nan_inf_filter: true
+
+  # Checkpointing
+  save_strategy: steps
+  save_steps: 500
+  save_total_limit: 2
+  save_safetensors: true
+  save_on_each_node: false
+  save_only_model: false
+  restore_callback_states_from_checkpoint: false
+
+  # Device
+  no_cuda: false
+  use_cpu: false
+  use_mps_device: false
+  seed: 42
+  data_seed: null
+  jit_mode_eval: false
+
+  # Precision
+  bf16: true
+  fp16: false
+  fp16_opt_level: O1
+  half_precision_backend: auto
+  bf16_full_eval: false
+  fp16_full_eval: false
+  tf32: true
+
+  # Distributed
+  local_rank: 0
+  ddp_backend: null
+  tpu_num_cores: null
+  tpu_metrics_debug: false
+  debug: []
+
+  # Dataloader
+  dataloader_drop_last: true
+  eval_steps: null
+  dataloader_num_workers: 4
+  dataloader_prefetch_factor: null
+  past_index: -1
+  run_name: aero_realtime_training
+  disable_tqdm: false
+  remove_unused_columns: false
+  label_names: null
+  load_best_model_at_end: false
+  metric_for_best_model: null
+  greater_is_better: null
+  ignore_data_skip: false
+
+  # FSDP config
+  fsdp: []
+  fsdp_min_num_params: 0
+  fsdp_config:
+    transformer_layer_cls_to_wrap:
+    - Qwen3VLTextDecoderLayer
+    reshard_after_forward: false
+    min_num_params: 0
+    xla: false
+    xla_fsdp_v2: false
+    xla_fsdp_grad_ckpt: false
+  fsdp_transformer_layer_cls_to_wrap: null
+
+  accelerator_config:
+    split_batches: false
+    dispatch_batches: null
+    even_batches: true
+    use_seedable_sampler: true
+    non_blocking: false
+    gradient_accumulation_kwargs: null
+  parallelism_config: null
+  deepspeed: null
+
+  # Optimization
+  label_smoothing_factor: 0.0
+  optim: adamw_torch_fused
+  optim_args: null
+  adafactor: false
+  group_by_length: false
+  length_column_name: length
+
+  # Reporting
+  report_to:
+  - wandb
+  project: huggingface
+  trackio_space_id: trackio
+
+  # Advanced
+  ddp_find_unused_parameters: null
+  ddp_bucket_cap_mb: null
+  ddp_broadcast_buffers: null
+  dataloader_pin_memory: true
+  dataloader_persistent_workers: false
+  skip_memory_metrics: true
+  use_legacy_prediction_loop: false
+  push_to_hub: false
+  resume_from_checkpoint: null
+  hub_model_id: null
+  hub_strategy: every_save
+  hub_token: null
+  hub_private_repo: null
+  hub_always_push: false
+  hub_revision: null
+
+  # Memory optimization
+  gradient_checkpointing: true
+  gradient_checkpointing_kwargs: null
+  include_inputs_for_metrics: false
+  include_for_metrics: []
+  eval_do_concat_batches: true
+  fp16_backend: auto
+  push_to_hub_model_id: null
+  push_to_hub_organization: null
+  mp_parameters: ''
+  auto_find_batch_size: false
+  full_determinism: false
+  torchdynamo: null
+  ray_scope: last
+  ddp_timeout: 1800
+
+  # Compilation
+  torch_compile: false
+  torch_compile_backend: null
+  torch_compile_mode: null
+
+  include_tokens_per_second: false
+  include_num_input_tokens_seen: 'no'
+  neftune_noise_alpha: null
+  optim_target_modules: null
+  batch_eval_metrics: false
+  eval_on_start: false
+
+  # Liger kernel for memory efficiency
+  use_liger_kernel: true
+  liger_kernel_config: null
+  eval_use_gather_object: false
+  average_tokens_across_devices: true
+  use_muon: false
+
+  # Freeze vision tower initially (train language model + audio + fusion)
+  freeze_modules: null
+
+  # Remove padding for efficiency
+  use_rmpad: true
+
+  # FSDP2 configuration
+  fsdp2: true
+  sp_ulysses_degree: 1
+  reduce_dtype: bfloat16
+  output_dtype: bfloat16
+  print_batch_input_steps: 5
+  enable_profiler: false
+  profiler_config:
+    start_step: 1
+    end_step: 3
+
+model_config:
+  extra_kwargs: {}
+  load_from_pretrained_path: null  # Override: path to aero_realtime_init checkpoint
+  load_from_config: null
+  attn_implementation: flash_attention_2
+  model_type: aero_realtime
+  torch_dtype: bfloat16
+  overwrite_config: null
+  monkey_patch_kwargs: null
+
+extra_kwargs: null

--- a/examples/aero_realtime/run.sh
+++ b/examples/aero_realtime/run.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+################################################################################
+# AeroRealtime Training — LLaVA-Video-178K (Normal Video QA)
+################################################################################
+#
+# DESCRIPTION:
+#   Train the AeroRealtime model (5.09B params) on LLaVA-Video-178K data.
+#   Uses Hydra --config-path / --config-name so all settings can be overridden
+#   from the command line.
+#
+# MODEL:
+#   - Vision: Qwen3-VL-4B vision tower (with built-in merger)
+#   - Audio: Qwen2-Audio-7B encoder (auto-extracted from video)
+#   - Language: Qwen3-VL-4B text model + lm_head
+#   - Fusion: timestep-aligned mean pooling (audio -> vision bins)
+#   - Design: additive dual-stream (text_stream_ids + vision features)
+#
+# PREREQUISITES:
+#   1. Prepare checkpoint:  python tools/prepare_init_weight/prepare_aero_realtime.py
+#   2. Convert data:        python tools/convert_data/convert_llava_video_to_parquet.py
+#   3. Install deps:        pip install flash-attn --no-build-isolation && pip install liger-kernel librosa
+#
+# USAGE:
+#   Set MODEL_PATH, DATA_PATH, DATA_FOLDER below, then run:
+#     bash scripts/launch/aero_realtime_train.sh
+#
+################################################################################
+
+# ----- Paths (edit these) ----------------------------------------------------
+MODEL_PATH=/path/to/aero_realtime_init
+DATA_PATH=/path/to/llava_video_0_30_s_cap_oe.parquet
+DATA_FOLDER=/path/to/LLaVA-Video-178K
+# -----------------------------------------------------------------------------
+
+NGPUS=8
+CONFIG_DIR=$(cd "$(dirname "$0")/../config" && pwd)
+
+torchrun --nproc_per_node="${NGPUS}" \
+    --nnodes="1" \
+    --node_rank="0" \
+    --master_addr="127.0.0.1" \
+    --master_port="8000" \
+    -m lmms_engine.launch.cli \
+    --config-path "${CONFIG_DIR}" \
+    --config-name aero_realtime \
+    model_config.load_from_pretrained_path="${MODEL_PATH}" \
+    dataset_config.processor_config.processor_name="${MODEL_PATH}" \
+    dataset_config.datasets.0.path="${DATA_PATH}" \
+    dataset_config.datasets.0.data_folder="${DATA_FOLDER}"
+
+################################################################################
+# EXAMPLES:
+#
+# Quick debug (5 steps, single GPU):
+#   python -m lmms_engine.launch.cli \
+#       --config-path scripts/config \
+#       --config-name aero_realtime \
+#       model_config.load_from_pretrained_path=${MODEL_PATH} \
+#       dataset_config.processor_config.processor_name=${MODEL_PATH} \
+#       dataset_config.datasets.0.path=${DATA_PATH} \
+#       dataset_config.datasets.0.data_folder=${DATA_FOLDER} \
+#       trainer_args.max_steps=5 \
+#       trainer_args.print_batch_input_steps=1
+#
+# Freeze vision tower:
+#   ... trainer_args.freeze_modules='["visual"]'
+#
+# Change learning rate:
+#   ... trainer_args.learning_rate=2e-5
+#
+# Multi-node (2 nodes):
+#   torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 \
+#       --master_addr=<RANK_0_IP> --master_port=8000 \
+#       -m lmms_engine.launch.cli \
+#       --config-path scripts/config \
+#       --config-name aero_realtime \
+#       model_config.load_from_pretrained_path=${MODEL_PATH} \
+#       ...
+#
+################################################################################

--- a/src/lmms_engine/datasets/collator/__init__.py
+++ b/src/lmms_engine/datasets/collator/__init__.py
@@ -1,8 +1,10 @@
+from .aero_realtime_collator import AeroRealtimeCollator
 from .bagel_collator import BagelCollator
 from .llava_collator import LLaVACollator
 from .vision_collator import VisionCollator
 
 __all__ = [
+    "AeroRealtimeCollator",
     "VisionCollator",
     "BagelCollator",
     "LLaVACollator",

--- a/src/lmms_engine/datasets/collator/aero_realtime_collator.py
+++ b/src/lmms_engine/datasets/collator/aero_realtime_collator.py
@@ -64,5 +64,27 @@ class AeroRealtimeCollator(VisionCollator):
             else:
                 # Convert numpy arrays to tensors if needed
                 values = [torch.from_numpy(v) if isinstance(v, np.ndarray) else v for v in values]
-                batched_inputs[key] = torch.concatenate(values, dim=0)
+                # Audio tensors from different samples may have different
+                # padded mel time lengths (variable across the outer batch).
+                # Right-pad along the last dim before concatenating on dim 0.
+                if key == "input_features":
+                    batched_inputs[key] = self._concat_pad_last_dim(values, pad_value=0.0)
+                elif key == "audio_attention_mask":
+                    batched_inputs[key] = self._concat_pad_last_dim(values, pad_value=0)
+                else:
+                    batched_inputs[key] = torch.concatenate(values, dim=0)
         return batched_inputs
+
+    @staticmethod
+    def _concat_pad_last_dim(tensors, pad_value):
+        """Right-pad each tensor's last dim to the batch max, then concat on dim 0."""
+        max_len = max(t.shape[-1] for t in tensors)
+        padded = []
+        for t in tensors:
+            if t.shape[-1] < max_len:
+                pad_shape = list(t.shape)
+                pad_shape[-1] = max_len - t.shape[-1]
+                pad = torch.full(pad_shape, pad_value, dtype=t.dtype, device=t.device)
+                t = torch.cat([t, pad], dim=-1)
+            padded.append(t)
+        return torch.cat(padded, dim=0)

--- a/src/lmms_engine/datasets/collator/aero_realtime_collator.py
+++ b/src/lmms_engine/datasets/collator/aero_realtime_collator.py
@@ -1,0 +1,68 @@
+import collections
+from dataclasses import dataclass
+from typing import Dict, Sequence
+
+import numpy as np
+import torch
+
+from .vision_collator import VisionCollator
+
+
+@dataclass
+class AeroRealtimeCollator(VisionCollator):
+    """Collator for AeroRealtime that additionally pads ``text_stream_ids``."""
+
+    def __call__(self, instances: Sequence[Dict]) -> Dict[str, torch.Tensor]:
+        if isinstance(instances[0], list):
+            instances = [inst for instance in instances for inst in instance]
+        inputs = collections.defaultdict(list)
+        for instance in instances:
+            for key, values in instance.items():
+                inputs[key].append(values)
+
+        batched_inputs = {}
+
+        if "input_ids" in inputs.keys():
+            input_ids = inputs.pop("input_ids")
+            input_ids = self.pad_sequence(
+                input_ids,
+                batch_first=True,
+                padding_value=self.processor.tokenizer.pad_token_id,
+            )
+            batched_inputs["input_ids"] = input_ids
+
+        if "labels" in inputs.keys():
+            labels = inputs.pop("labels")
+            labels = self.pad_sequence(
+                labels,
+                batch_first=True,
+                padding_value=-100,
+            )
+            batched_inputs["labels"] = labels
+
+        if "text_stream_ids" in inputs.keys():
+            text_stream_ids = inputs.pop("text_stream_ids")
+            text_stream_ids = self.pad_sequence(
+                text_stream_ids,
+                batch_first=True,
+                padding_value=self.processor.tokenizer.pad_token_id,
+            )
+            batched_inputs["text_stream_ids"] = text_stream_ids
+
+        if "attention_mask" in inputs.keys():
+            inputs.pop("attention_mask")
+
+        attention_mask = input_ids.ne(self.processor.tokenizer.pad_token_id).long()
+        batched_inputs["attention_mask"] = attention_mask
+
+        # Remaining keys: concatenate tensors, pass through scalars
+        for key, values in inputs.items():
+            if isinstance(values[0], bool) or (
+                isinstance(values[0], (int, float)) and not isinstance(values[0], torch.Tensor)
+            ):
+                batched_inputs[key] = values[0]
+            else:
+                # Convert numpy arrays to tensors if needed
+                values = [torch.from_numpy(v) if isinstance(v, np.ndarray) else v for v in values]
+                batched_inputs[key] = torch.concatenate(values, dim=0)
+        return batched_inputs

--- a/src/lmms_engine/datasets/iterable/__init__.py
+++ b/src/lmms_engine/datasets/iterable/__init__.py
@@ -1,3 +1,4 @@
+from .aero_realtime_iterable_dataset import AeroRealtimeIterableDataset
 from .bagel_iterable_dataset import BagelIterableDataset
 from .base_iterable_dataset import BaseIterableDataset
 from .fineweb_edu_dataset import FinewebEduDataset
@@ -8,6 +9,7 @@ from .qwen_omni_iterable_dataset import QwenOmniIterableDataset
 from .vision_iterable_dataset import VisionSFTIterableDataset
 
 __all__ = [
+    "AeroRealtimeIterableDataset",
     "BaseIterableDataset",
     "FinewebEduDataset",
     "MultiModalIterableDataset",

--- a/src/lmms_engine/datasets/iterable/aero_realtime_iterable_dataset.py
+++ b/src/lmms_engine/datasets/iterable/aero_realtime_iterable_dataset.py
@@ -1,0 +1,306 @@
+# coding=utf-8
+# Copyright 2025 LMMs-Lab team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AeroRealtime iterable dataset.
+
+Handles loading of video+audio data and realtime text segments for
+AeroRealtime training.  Supports both normal video QA and realtime
+training data (where assistant messages contain ``realtime_text``
+content items with ``start_sec`` timestamps).
+
+Audio is auto-extracted from video files using librosa.
+"""
+
+import json
+import os
+import warnings
+from typing import Any, Dict, List, Optional, Tuple
+
+import av
+import librosa
+from loguru import logger
+
+warnings.filterwarnings("ignore", message=".*PySoundFile.*")
+warnings.filterwarnings("ignore", message=".*__audioread_load.*", category=FutureWarning)
+
+import numpy as np
+import torch
+from PIL import Image
+
+from lmms_engine.datasets.collator import AeroRealtimeCollator
+from lmms_engine.datasets.iterable.multimodal_iterable_dataset import (
+    MultiModalIterableDataset,
+)
+from lmms_engine.mapping_func import register_dataset
+from lmms_engine.utils.train_utils import TrainUtilities
+
+
+@register_dataset("aero_realtime_iterable")
+class AeroRealtimeIterableDataset(MultiModalIterableDataset):
+    """Dataset for AeroRealtime training.
+
+    Extends VisionSFTIterableDataset with:
+    - Audio extraction from video files
+    - ``realtime_text`` content type handling
+    - Video metadata passthrough for timestamp computation
+    """
+
+    def load_from_json(self, data, data_folder=None) -> Dict[str, torch.Tensor]:
+        images_list = []
+        videos = []
+        audios = []
+        realtime_segments = []
+        video_paths = []
+        kwargs = {}
+
+        messages = data["messages"]
+        if isinstance(messages, str):
+            messages = json.loads(messages)
+
+        is_realtime = bool(data.get("realtime", False))
+
+        # First pass: collect media references and realtime segments
+        for message in messages:
+            message_time = message.get("time")
+            if is_realtime and message_time is not None and message["role"] in ["user", "assistant"]:
+                text = self._extract_text_content(message.get("content", []))
+                if text:
+                    realtime_segments.append(
+                        {
+                            "time": float(message_time),
+                            "role": message["role"],
+                            "text": text,
+                        }
+                    )
+                continue
+
+            for content in message["content"]:
+                content_type = content.get("type")
+                if content_type == "image_url":
+                    images_list.append(content["image_url"]["url"])
+                elif content_type == "video_url":
+                    video_url_dict = content["video_url"]
+                    video_url = video_url_dict["url"]
+                    if data_folder is not None:
+                        video_path = os.path.join(data_folder, video_url)
+                    else:
+                        video_path = video_url
+                    extra = {k: v for k, v in video_url_dict.items() if k != "url" and v is not None}
+                    video_paths.append((video_path, extra))
+
+                    # Load video frames with metadata
+                    frames, video_metadata, sample_fps = self._load_video_with_metadata(
+                        video_url, data_folder=data_folder, video_kwargs=extra or None
+                    )
+                    videos.append(frames)
+                    kwargs["fps"] = sample_fps
+                    kwargs["video_metadata"] = video_metadata
+                    kwargs["do_sample_frames"] = False
+
+                elif content_type == "realtime_text":
+                    realtime_segments.append(
+                        {
+                            "time": content["start_sec"],
+                            "role": "assistant",
+                            "text": content["text"],
+                        }
+                    )
+
+        # Extract audio from video files
+        if video_paths:
+            for video_path, extra in video_paths:
+                offset = float(extra.get("video_start", 0.0) or 0.0)
+                end = extra.get("video_end")
+                duration = (float(end) - offset) if end is not None else None
+                audio = self._extract_audio_from_video(video_path, offset=offset, duration=duration)
+                audios.append(audio)
+
+        # Convert messages to HF format (realtime_text items are passed through)
+        hf_messages = TrainUtilities.convert_open_to_hf(messages)
+
+        # Load images
+        if data_folder is not None:
+            images = [Image.open(os.path.join(data_folder, img_path)) for img_path in images_list]
+        else:
+            images = [Image.open(img_path) for img_path in images_list]
+
+        if len(images) == 0:
+            images = None
+        if len(videos) == 0:
+            videos = None
+        if len(audios) == 0:
+            audios = None
+        if len(realtime_segments) == 0:
+            realtime_segments = None
+
+        inputs = self.processor.process(
+            images=images,
+            hf_messages=hf_messages,
+            audios=audios,
+            sampling_rate=self.processor.sampling_rate,
+            videos=videos,
+            realtime_segments=realtime_segments,
+            **kwargs,
+        )
+        return inputs
+
+    @staticmethod
+    def _extract_text_content(content) -> str:
+        if isinstance(content, str):
+            return content
+        texts = []
+        for item in content:
+            if item and item.get("type") == "text" and item.get("text"):
+                texts.append(item["text"])
+        return "\n".join(texts)
+
+    def _load_video_with_metadata(
+        self,
+        video_path: str,
+        data_folder: Optional[str] = None,
+        video_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[np.ndarray, object, float]:
+        """Load video frames and return metadata for timestamp computation.
+
+        Uses qwen_vl_utils fetch_video with return_video_metadata=True to get
+        frame indices and fps needed for timestamp computation.
+
+        Disables torchvision fallback to avoid 30-min hangs on corrupted
+        videos that would cause NCCL timeouts.
+
+        Args:
+            video_path: Path to video file (relative to data_folder).
+            data_folder: Optional folder to prepend.
+            video_kwargs: Optional extra ele fields forwarded to ``fetch_video``
+                (e.g. ``video_start`` / ``video_end`` for sub-clip seek).
+
+        Returns:
+            Tuple of (frames, video_metadata, sample_fps).
+        """
+        from qwen_vl_utils import fetch_video
+        from qwen_vl_utils import vision_process as _vp
+
+        if data_folder is not None:
+            full_path = os.path.join(data_folder, video_path)
+        else:
+            full_path = video_path
+
+        video_dict = {
+            "type": "video",
+            "video": f"file://{full_path}",
+            "min_frames": 1,
+            "max_pixels": getattr(self.config, "video_max_pixels", 360 * 420),
+            "max_frames": getattr(self.config, "video_max_frames", 512),
+            "min_pixels": getattr(self.config, "video_min_pixels", 28 * 28),
+        }
+        if video_kwargs:
+            video_dict.update(video_kwargs)
+
+        if self.config.video_sampling_strategy == "frame_num":
+            n_frames = self.config.frame_num
+            video_dict["nframes"] = n_frames
+        elif self.config.video_sampling_strategy == "fps":
+            video_dict["fps"] = self.config.fps
+        else:
+            raise ValueError(f"Invalid video sampling strategy: {self.config.video_sampling_strategy}")
+
+        # Temporarily remove torchvision from backends to prevent slow fallback
+        # that can hang for 30+ minutes on problematic videos, causing NCCL timeout.
+        _tv_backup = _vp.VIDEO_READER_BACKENDS.pop("torchvision", None)
+        try:
+            video_inputs, sample_fps = fetch_video(
+                video_dict,
+                return_video_sample_fps=True,
+                return_video_metadata=True,
+            )
+        finally:
+            if _tv_backup is not None:
+                _vp.VIDEO_READER_BACKENDS["torchvision"] = _tv_backup
+
+        frames, video_metadata = video_inputs
+        frames = frames.numpy()
+        return frames, video_metadata, sample_fps
+
+    def _extract_audio_from_video(
+        self,
+        video_path: str,
+        target_sr: Optional[int] = None,
+        offset: float = 0.0,
+        duration: Optional[float] = None,
+    ) -> np.ndarray:
+        """Extract a mono audio window from a video using PyAV.
+
+        PyAV does container-level seek so reading a small window deep inside a
+        long mp4 (e.g. Inf-Stream's multi-hour clips) costs O(seek) instead of
+        O(offset) — ~100x faster than ``librosa.load(..., offset=...)`` which
+        falls back to audioread and decodes from t=0.
+
+        On any failure (no audio track, decode error) returns silence of length
+        ``duration`` (or the video's own duration if unknown, then 1s) so the
+        audio tower still participates in the forward pass and downstream
+        supervision still has audio_pad slots to land in. For video-only data
+        like LiveCC, silence is itself a valid training signal.
+        """
+        target_sr = target_sr or self.processor.sampling_rate
+        try:
+            with av.open(video_path) as container:
+                stream = container.streams.audio[0]
+                src_sr = int(stream.rate)
+                end_t = offset + duration if duration is not None else float("inf")
+                if offset > 0:
+                    container.seek(int(offset / float(stream.time_base)), stream=stream)
+                chunks = []
+                for frame in container.decode(stream):
+                    t = float(frame.pts * frame.time_base)
+                    if t > end_t:
+                        break
+                    if t + frame.samples / float(frame.sample_rate) < offset:
+                        continue
+                    arr = frame.to_ndarray()
+                    if arr.ndim == 2:  # planar (channels, samples) -> mono
+                        arr = arr.mean(axis=0)
+                    chunks.append(arr)
+            if not chunks:
+                raise RuntimeError("decoded zero audio frames")
+
+            audio = np.concatenate(chunks)
+            if audio.dtype.kind == "i":
+                audio = audio.astype(np.float32) / np.iinfo(audio.dtype).max
+            else:
+                audio = audio.astype(np.float32)
+            if src_sr != target_sr:
+                audio = librosa.resample(audio, orig_sr=src_sr, target_sr=target_sr)
+            if duration is not None:
+                audio = audio[: int(round(duration * target_sr))]
+            return audio
+        except Exception as e:
+            silence_secs = duration if duration and duration > 0 else self._probe_video_duration(video_path) or 1.0
+            # logger.debug(
+            #     f"Audio extraction failed for {video_path} "
+            #     f"(offset={offset}, duration={duration}): {e}. "
+            #     f"Falling back to {silence_secs:.2f}s silence."
+            # )
+            return np.zeros(int(round(silence_secs * target_sr)), dtype=np.float32)
+
+    @staticmethod
+    def _probe_video_duration(video_path: str) -> Optional[float]:
+        try:
+            with av.open(video_path) as c:
+                return float(c.duration) / float(av.time_base) if c.duration else None
+        except Exception:
+            return None
+
+    def get_collator(self):
+        return AeroRealtimeCollator(self.processor)

--- a/src/lmms_engine/datasets/iterable/aero_realtime_iterable_dataset.py
+++ b/src/lmms_engine/datasets/iterable/aero_realtime_iterable_dataset.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import av
 import librosa
+import soundfile as sf
 from loguru import logger
 
 warnings.filterwarnings("ignore", message=".*PySoundFile.*")
@@ -126,6 +127,21 @@ class AeroRealtimeIterableDataset(MultiModalIterableDataset):
                 duration = (float(end) - offset) if end is not None else None
                 audio = self._extract_audio_from_video(video_path, offset=offset, duration=duration)
                 audios.append(audio)
+
+        # Mix any user-provided TTS audio onto the (single) video audio track.
+        # ``user_audio`` is a list of ``{"path", "start_time"}`` where
+        # ``start_time`` is relative to the chunk start (= video_start).  This
+        # is how EgoIT realtime data injects spoken questions.
+        user_audio_entries = data.get("user_audio")
+        if user_audio_entries is not None and len(user_audio_entries) > 0:
+            if not audios:
+                raise ValueError("user_audio requires a video track to mix onto")
+            audios[0] = self._mix_user_audio_onto_track(
+                base=audios[0],
+                user_audio_entries=user_audio_entries,
+                target_sr=self.processor.sampling_rate,
+                data_folder=data_folder,
+            )
 
         # Convert messages to HF format (realtime_text items are passed through)
         hf_messages = TrainUtilities.convert_open_to_hf(messages)
@@ -301,6 +317,54 @@ class AeroRealtimeIterableDataset(MultiModalIterableDataset):
                 return float(c.duration) / float(av.time_base) if c.duration else None
         except Exception:
             return None
+
+    @staticmethod
+    def _load_audio_file(path: str, target_sr: int) -> Optional[np.ndarray]:
+        """Load a standalone wav file as mono float32 at ``target_sr``."""
+        try:
+            audio, sr = sf.read(path, dtype="float32", always_2d=False)
+        except Exception:
+            return None
+        if audio.ndim == 2:
+            audio = audio.mean(axis=1)
+        if sr != target_sr:
+            audio = librosa.resample(audio, orig_sr=sr, target_sr=target_sr)
+        return audio.astype(np.float32, copy=False)
+
+    @classmethod
+    def _mix_user_audio_onto_track(
+        cls,
+        base: np.ndarray,
+        user_audio_entries: List[Dict[str, Any]],
+        target_sr: int,
+        data_folder: Optional[str],
+        base_attenuation: float = 0.3,
+    ) -> np.ndarray:
+        """Overlay TTS waveforms on a base audio track at their ``start_time``.
+
+        ``base`` is the audio extracted from the video clip; each entry in
+        ``user_audio_entries`` is ``{"path", "start_time"}`` with ``start_time``
+        in seconds relative to the clip start.  The base track is attenuated in
+        the overlap window so the spoken TTS dominates without clipping; the
+        whole track is clipped to ``[-1, 1]`` at the end.
+
+        Returns the modified base array (mutated in place for efficiency).
+        """
+        base_len = base.shape[0]
+        for entry in user_audio_entries:
+            rel = entry["path"]
+            full = os.path.join(data_folder, rel) if data_folder is not None else rel
+            wav = cls._load_audio_file(full, target_sr=target_sr)
+            if wav is None or wav.shape[0] == 0:
+                continue
+            st = max(0.0, float(entry.get("start_time", 0.0)))
+            ofs = int(round(st * target_sr))
+            if ofs >= base_len:
+                continue
+            end_ofs = min(ofs + wav.shape[0], base_len)
+            base[ofs:end_ofs] = base[ofs:end_ofs] * base_attenuation + wav[: end_ofs - ofs]
+        np.clip(base, -1.0, 1.0, out=base)
+        return base
 
     def get_collator(self):
         return AeroRealtimeCollator(self.processor)

--- a/src/lmms_engine/datasets/multimodal_mixin.py
+++ b/src/lmms_engine/datasets/multimodal_mixin.py
@@ -1,11 +1,16 @@
 import os
 import random
+import warnings
 from copy import deepcopy
 from io import BytesIO
 from multiprocessing import cpu_count
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import librosa
+
+warnings.filterwarnings("ignore", message=".*PySoundFile.*")
+warnings.filterwarnings("ignore", message=".*__audioread_load.*", category=FutureWarning)
+
 import numpy as np
 import soundfile as sf
 import torch

--- a/src/lmms_engine/datasets/processor/__init__.py
+++ b/src/lmms_engine/datasets/processor/__init__.py
@@ -1,4 +1,5 @@
 from .aero_processor import AeroDataProcessor
+from .aero_realtime_processor import AeroRealtimeDataProcessor
 from .bagel_processor import BagelDataProcessor
 from .base_qwen2_5_processor import BaseQwen2_5_DataProcessor
 from .config import ProcessorConfig
@@ -20,6 +21,7 @@ from .wanvideo_processor import WanVideoDataProcessor
 __all__ = [
     "ProcessorConfig",
     "AeroDataProcessor",
+    "AeroRealtimeDataProcessor",
     "BaseQwen2_5_DataProcessor",
     "LLaVADataProcessor",
     "LLaVAVideoDataProcessor",

--- a/src/lmms_engine/datasets/processor/aero_realtime_processor.py
+++ b/src/lmms_engine/datasets/processor/aero_realtime_processor.py
@@ -56,6 +56,10 @@ class AeroRealtimeDataProcessor(Qwen3_VLDataProcessor):
 
     def __init__(self, config: ProcessorConfig) -> None:
         self.config = config
+        # Fraction of <|rt_pad|> labels to mask out (set to -100) so the
+        # model is not asked to predict silence at every audio_pad slot.
+        # 0.0 = supervise all, 1.0 = never supervise rt_pad.
+        self.rt_pad_label_mask_ratio = float((config.extra_kwargs or {}).get("rt_pad_label_mask_ratio", 0.0))
 
     def build(self):
         self.processor = self._build_processor()
@@ -181,6 +185,21 @@ class AeroRealtimeDataProcessor(Qwen3_VLDataProcessor):
         )
 
         # ==============================================================
+        # 0. Normal-QA tail planning: if hf_messages has assistant turns
+        #    AND we have video, compute per-pair token counts so we can
+        #    append matching silence audio features after the main FE pass
+        #    (we don't push silence through the feature extractor because
+        #    ``padding="longest"`` would pad short tails up to the video
+        #    audio length, producing zero-length encoder chunks).
+        # ==============================================================
+        qa_silence_token_counts: List[int] = []
+        if realtime_segments is None and videos is not None and hf_messages is not None:
+            qa_pairs, _ = self._extract_qa_pairs(hf_messages)
+            for _, a_text in qa_pairs:
+                a_tok = self.tokenizer.encode(a_text, add_special_tokens=False)
+                qa_silence_token_counts.append(len(a_tok))
+
+        # ==============================================================
         # 1. Process images
         # ==============================================================
         image_inputs = {}
@@ -304,6 +323,18 @@ class AeroRealtimeDataProcessor(Qwen3_VLDataProcessor):
             )
 
         # ==============================================================
+        # 5b. Randomly mask a fraction of rt_pad supervision so the model
+        #     isn't forced to predict silence at every audio_pad slot.
+        # ==============================================================
+        if self.rt_pad_label_mask_ratio > 0.0 and "labels" in inputs:
+            labels = inputs["labels"]
+            rt_pad_mask = labels == self.rt_pad_id
+            if rt_pad_mask.any():
+                drop = torch.rand_like(labels, dtype=torch.float) < self.rt_pad_label_mask_ratio
+                labels = labels.masked_fill(rt_pad_mask & drop, -100)
+                inputs["labels"] = labels
+
+        # ==============================================================
         # 6. Pack vision/audio tensors into output
         # ==============================================================
         if images is not None:
@@ -342,11 +373,60 @@ class AeroRealtimeDataProcessor(Qwen3_VLDataProcessor):
             inputs["input_features"] = feats
             inputs["audio_attention_mask"] = enc_mask
 
+            # ----------------------------------------------------------
+            # Append silence audio chunks for normal-QA tail envelopes.
+            # Each tail token = one valid silence chunk (features all
+            # zero, enc_mask all one). Done *after* FE so we don't
+            # trigger ``padding="longest"`` against the video audio.
+            # ----------------------------------------------------------
+            total_tail = sum(qa_silence_token_counts)
+            if total_tail > 0 and self.processor.chunk_audio:
+                F_dim = feats.shape[-2]
+                tail_feats = feats.new_zeros((total_tail, F_dim, chunk_mel))
+                tail_mask = enc_mask.new_ones((total_tail, chunk_enc))
+                inputs["input_features"] = torch.cat([feats, tail_feats], dim=0)
+                inputs["audio_attention_mask"] = torch.cat([enc_mask, tail_mask], dim=0)
+
         return inputs
 
     # ------------------------------------------------------------------
     # Core: build input_ids, text_stream_ids, labels
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_qa_pairs(hf_messages):
+        """Split hf_messages into video-only messages + [(q_text, a_text), ...].
+
+        Question text that lives in the same user turn as the video is
+        attached to the *next* assistant turn (so all q+a tails go after
+        the video envelope, inside the same user turn).
+        """
+        qa_pairs = []
+        video_only = []
+        pending_q_parts = []
+        for msg in hf_messages:
+            role = msg["role"]
+            if role == "system":
+                video_only.append(msg)
+                continue
+            if role == "user":
+                video_content, text_parts = [], []
+                for c in msg["content"]:
+                    ctype = c.get("type")
+                    if ctype in ("video", "image", "audio"):
+                        video_content.append(c)
+                    elif ctype == "text" and c.get("text"):
+                        text_parts.append(c["text"])
+                if video_content:
+                    video_only.append({"role": "user", "content": video_content})
+                pending_q_parts.extend(text_parts)
+            elif role == "assistant":
+                a_parts = [c["text"] for c in msg["content"] if c.get("type") == "text" and c.get("text")]
+                if not a_parts:
+                    continue
+                qa_pairs.append(("\n".join(pending_q_parts).strip(), "\n".join(a_parts)))
+                pending_q_parts = []
+        return qa_pairs, video_only
 
     def _build_normal_qa_ids_and_labels(
         self,
@@ -361,63 +441,90 @@ class AeroRealtimeDataProcessor(Qwen3_VLDataProcessor):
         system_message: str = "You are a helpful assistant",
         add_system_prompt: bool = True,
     ) -> dict:
-        """Build input_ids, text_stream_ids, and labels from HF messages.
+        """Build input_ids/text_stream_ids/labels for normal video QA.
 
-        For normal video QA the text_stream_ids only differ from input_ids
-        on audio pad positions, where all ``<|audio_pad|>`` slots become
-        ``<|rt_pad|>`` context. Normal QA keeps standard assistant labels;
-        realtime span labels are built by ``_build_realtime_ids_and_labels``.
+        When the conversation contains assistant turns *and* a video, the
+        assistant answers are NOT supervised as plain text after the video
+        envelope.  Instead each ``(question, answer)`` pair is appended
+        inside the same user turn as::
 
-        Video placeholders and envelope boundary tokens keep their original
-        ids; vision features replace video placeholder embeddings in the model.
+            q_k <|audio_start|><|audio_pad|>×n_k <|audio_end|>
+
+        where ``n_k = len(tokenize(a_k))``.  The ``input_ids`` carry silent
+        ``<|audio_pad|>`` slots, ``text_stream_ids`` carry the answer tokens
+        in those same slots, and ``labels`` supervise only the answer tokens.
+        The caller (dataset) is responsible for appending matching silence
+        audio (``n_k * 1280`` samples per pair) so the audio feature
+        extractor produces exactly ``n_k`` audio tokens per tail envelope.
+
+        When there are no assistant turns OR no video, falls back to the
+        original behaviour: standard Qwen template labels + ``rt_pad``
+        rewrite on audio_pad positions.
         """
-        results = self.get_qwen_template_labels(
-            hf_messages,
-            num_image_tokens,
-            num_video_tokens,
-            video_metadata,
-            video_grid_thw,
+
+        # --------------------------------------------------------------
+        # 1. Split hf_messages -> video_only_messages + qa_pairs
+        #    (process() may have already done this; idempotent)
+        # --------------------------------------------------------------
+        qa_pairs, video_only_messages = self._extract_qa_pairs(hf_messages)
+        has_video = video_grid_thw is not None
+
+        use_qa_tail = bool(qa_pairs) and has_video
+        base_messages = video_only_messages if use_qa_tail else hf_messages
+
+        # --------------------------------------------------------------
+        # 2+3. Delegate to realtime path with empty segments to get
+        #      input_ids / text_stream_ids / labels for the video portion.
+        #      Video-period audio_pad labels become rt_pad (silence).
+        # --------------------------------------------------------------
+        rt_result = self._build_realtime_ids_and_labels(
+            hf_messages=base_messages,
+            num_image_tokens=num_image_tokens,
+            num_video_tokens=num_video_tokens,
+            video_grid_thw=video_grid_thw,
+            video_metadata=video_metadata,
             audio_per_chunk_per_video=audio_per_chunk_per_video,
+            audio_attention_mask=audio_attention_mask,
+            realtime_segments=[],
             system_message=system_message,
             add_system_prompt=add_system_prompt,
         )
-        input_id = results["input_ids"].tolist()
-        target = results["labels"].tolist()
+        input_id = rt_result["input_ids"].tolist()
+        text_stream_id = rt_result["text_stream_ids"].tolist()
+        target = rt_result["labels"].tolist()
 
-        # ==============================================================
-        # Build text_stream_ids
-        # ==============================================================
-        has_video = video_grid_thw is not None
-        has_audio = audio_attention_mask is not None
-        text_stream_id = list(input_id)  # start as a copy of input_ids
+        # --------------------------------------------------------------
+        # 4. Append tail (q + silent audio envelope) for each QA pair
+        # --------------------------------------------------------------
+        if use_qa_tail:
+            audio_start_id = self.tokenizer.convert_tokens_to_ids(self.processor.audio_start_token)
+            audio_end_id = self.tokenizer.convert_tokens_to_ids(self.processor.audio_end_token)
+            audio_pad_id = self.audio_token_id
 
-        if has_video and has_audio:
-            # video + audio: only audio pads carry realtime stream context
-            self.processor._fill_text_stream_video_audio(
-                stream=text_stream_id,
-                video_grid_thw=video_grid_thw,
-                video_metadata=video_metadata,
-                temporal_patch_size=getattr(self.processor.video_processor, "temporal_patch_size", 2),
-                audio_start_id=self.tokenizer.convert_tokens_to_ids(self.processor.audio_start_token),
-                audio_end_id=self.tokenizer.convert_tokens_to_ids(self.processor.audio_end_token),
-                rt_pad_id=self.rt_pad_id,
-            )
-        elif has_audio:
-            # audio-only: single envelope per audio sample
-            n_samples = audio_attention_mask.shape[0]
-            for s_idx in range(n_samples):
-                self.processor._fill_text_stream_audio_only(
-                    stream=text_stream_id,
-                    sample_idx=s_idx,
-                    audio_attention_mask=audio_attention_mask,
-                    audio_start_id=self.tokenizer.convert_tokens_to_ids(self.processor.audio_start_token),
-                    audio_end_id=self.tokenizer.convert_tokens_to_ids(self.processor.audio_end_token),
-                    audio_pad_id=self.audio_token_id,
-                    rt_start_id=self.rt_start_id,
-                    rt_pad_id=self.rt_pad_id,
-                    rt_speak_id=self.rt_speak_id,
-                )
-        # video-only (no audio): no text_stream_ids (matches processor)
+            # Strip trailing "<|im_end|>\n" so the tail sits inside the same user turn.
+            im_end_tokens = self.tokenizer.encode("<|im_end|>\n", add_special_tokens=False)
+            tail_len = len(im_end_tokens)
+            assert (
+                input_id[-tail_len:] == im_end_tokens
+            ), f"expected trailing im_end tokens {im_end_tokens}, got {input_id[-tail_len:]}"
+            input_id = input_id[:-tail_len]
+            text_stream_id = text_stream_id[:-tail_len]
+            target = target[:-tail_len]
+
+            for q_text, a_text in qa_pairs:
+                q_tok = self.tokenizer.encode(q_text, add_special_tokens=False) if q_text else []
+                a_tok = self.tokenizer.encode(a_text, add_special_tokens=False)
+                n_k = len(a_tok)
+                if n_k == 0:
+                    continue
+                input_id += q_tok + [audio_start_id] + [audio_pad_id] * n_k + [audio_end_id]
+                text_stream_id += q_tok + [audio_start_id] + a_tok + [audio_end_id]
+                target += [-100] * len(q_tok) + [-100] + a_tok + [-100]
+
+            # Re-append "<|im_end|>\n"
+            input_id += im_end_tokens
+            text_stream_id += im_end_tokens
+            target += [-100] * tail_len
 
         input_id = torch.tensor(input_id, dtype=torch.long)
         target = torch.tensor(target, dtype=torch.long)
@@ -426,9 +533,7 @@ class AeroRealtimeDataProcessor(Qwen3_VLDataProcessor):
             input_ids=input_id,
             labels=target,
         )
-        # text_stream_ids only when audio is present (= streaming mode)
-        if has_audio:
-            result["text_stream_ids"] = torch.tensor(text_stream_id, dtype=torch.long)
+        result["text_stream_ids"] = torch.tensor(text_stream_id, dtype=torch.long)
 
         return result
 

--- a/src/lmms_engine/datasets/processor/aero_realtime_processor.py
+++ b/src/lmms_engine/datasets/processor/aero_realtime_processor.py
@@ -315,29 +315,31 @@ class AeroRealtimeDataProcessor(Qwen3_VLDataProcessor):
                 inputs[key] = value
 
         if audios is not None:
-            # Model expects `input_features` for audio
-            inputs["input_features"] = audio_inputs["input_features"]
-            # Convert audio_attention_mask from mel-level (T_mel) to
-            # post-conv2 encoder length (T_enc = T_mel // 2) — what
-            # VoxtralRealtimeEncoder.forward expects. ``mel_mask`` from the
-            # FE lags ``input_features`` by ``pad_offset`` frames.
-            mel_mask = audio_inputs["audio_attention_mask"]
-            if not isinstance(mel_mask, torch.Tensor):
-                mel_mask = torch.as_tensor(mel_mask)
-            input_features = audio_inputs["input_features"]
-            if not isinstance(input_features, torch.Tensor):
-                input_features = torch.as_tensor(input_features)
-            T_mel = input_features.shape[-1]
-            pad_offset = max(0, T_mel - mel_mask.shape[-1])
-            mel_lengths_t = mel_mask.sum(-1).to(torch.long) + pad_offset
-            B = mel_mask.shape[0]
-            T_enc = T_mel // 2
-            enc_mask = torch.zeros(B, T_enc, dtype=torch.long)
-            for i in range(B):
-                m = min(int(mel_lengths_t[i].item()), T_mel)
-                enc_m = m // 2 if m > 0 else 0
-                if enc_m > 0:
-                    enc_mask[i, :enc_m] = 1
+            # Emit audio features + post-conv2 encoder mask. Mirrors
+            # ``AeroRealtimeProcessor.__call__`` section 8:
+            #   - chunk_audio (default): reshape into [B*N, F, chunk_mel] rows,
+            #     one per LM audio token; mask [B*N, chunk_enc].
+            #   - flat: keep [B, F, T_mel]; downsample mel_mask by 2 → [B, T_enc].
+            feats = torch.as_tensor(audio_inputs["input_features"])
+            mel_mask = torch.as_tensor(audio_inputs["audio_attention_mask"])
+            mel_mask = torch.nn.functional.pad(mel_mask, (0, feats.shape[-1] - mel_mask.shape[-1]), value=1)
+
+            if self.processor.chunk_audio:
+                chunk_mel = self.processor.audio_length_per_tok
+                chunk_enc = chunk_mel // 2
+                pad = (-feats.shape[-1]) % chunk_mel
+                feats = torch.nn.functional.pad(feats, (0, pad))
+                mel_mask = torch.nn.functional.pad(mel_mask, (0, pad))
+                B, F, T_mel = feats.shape
+                N = T_mel // chunk_mel
+                feats = feats.view(B, F, N, chunk_mel).permute(0, 2, 1, 3).reshape(B * N, F, chunk_mel)
+                chunk_valid = mel_mask.view(B, N, chunk_mel).all(-1)  # [B, N]
+                enc_mask = chunk_valid.unsqueeze(-1).expand(B, N, chunk_enc).reshape(B * N, chunk_enc).long()
+            else:
+                T_enc = mel_mask.shape[-1] // 2
+                enc_mask = mel_mask[:, : T_enc * 2].view(mel_mask.shape[0], T_enc, 2).all(-1).long()
+
+            inputs["input_features"] = feats
             inputs["audio_attention_mask"] = enc_mask
 
         return inputs

--- a/src/lmms_engine/datasets/processor/aero_realtime_processor.py
+++ b/src/lmms_engine/datasets/processor/aero_realtime_processor.py
@@ -1,0 +1,809 @@
+# coding=utf-8
+# Copyright 2025 LMMs-Lab team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AeroRealtime data processor.
+
+Handles training data processing for the AeroRealtime model.  Supports both
+normal video QA (assistant replies after video) and realtime training
+(assistant text segments are placed at specific temporal positions during
+video playback).
+
+The processor builds ``text_stream_ids`` on the audio timeline. ``<|rt_pad|>``
+is silence context only; labels supervise ``<|rt_speak|>``, speech span
+boundaries (``<|rt_start|>`` / ``<|rt_end|>``), and speech text tokens.
+"""
+
+from typing import Dict, List, Optional
+
+import numpy as np
+import torch
+from PIL.Image import Image
+
+from lmms_engine.datasets.processor.qwen3_vl_processor import Qwen3_VLDataProcessor
+from lmms_engine.mapping_func import register_processor
+from lmms_engine.models.aero_realtime.processing_aero_realtime import (
+    AeroRealtimeProcessor,
+    AeroRealtimeProcessorKwargs,
+)
+from lmms_engine.utils import DataUtilities
+
+from .config import ProcessorConfig
+
+
+@register_processor("aero_realtime")
+class AeroRealtimeDataProcessor(Qwen3_VLDataProcessor):
+    """Data processor for AeroRealtime training.
+
+    Builds ``input_ids``, ``text_stream_ids``, and ``labels`` for the
+    realtime audio-stream training design.  Handles:
+    - Normal video QA: audio timeline filled with ``<|rt_pad|>`` context
+    - Realtime training: boundary and text labels on audio tokens
+    - Image-only: standard scatter (no text_stream_ids)
+    - Audio extraction from video for audio-vision fusion
+    """
+
+    def __init__(self, config: ProcessorConfig) -> None:
+        self.config = config
+
+    def build(self):
+        self.processor = self._build_processor()
+        # Override chat template to handle realtime_text content type
+        self.processor.chat_template = self.chat_template
+
+    def _build_processor(self):
+        processor = AeroRealtimeProcessor.from_pretrained(self.config.processor_name)
+        # Set video processor parameters from extra_kwargs
+        video_max_pixels = self.config.extra_kwargs.get("video_max_pixels", None)
+        video_min_pixels = self.config.extra_kwargs.get("video_min_pixels", None)
+        if video_max_pixels and hasattr(processor, "video_processor"):
+            processor.video_processor.max_pixels = video_max_pixels
+        if video_min_pixels and hasattr(processor, "video_processor"):
+            processor.video_processor.min_pixels = video_min_pixels
+
+        image_max_pixels = self.config.extra_kwargs.get("image_max_pixels", None)
+        image_min_pixels = self.config.extra_kwargs.get("image_min_pixels", None)
+        if image_max_pixels and hasattr(processor, "image_processor"):
+            processor.image_processor.max_pixels = image_max_pixels
+        if image_min_pixels and hasattr(processor, "image_processor"):
+            processor.image_processor.min_pixels = image_min_pixels
+
+        return processor
+
+    def save_pretrained(self, save_directory: str):
+        if not hasattr(self, "processor"):
+            raise ValueError("Processor has not been built yet. Call build() first.")
+        new_processor = self._build_processor()
+        new_processor.save_pretrained(save_directory)
+
+    # ------------------------------------------------------------------
+    # Token ID helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def special_tokens(self):
+        if not hasattr(self, "_special_tokens"):
+            self._special_tokens = DataUtilities.get_special_tokens(
+                self.processor.tokenizer,
+                extra_tokens=["<|im_start|>", "<|im_end|>"],
+            )
+        return self._special_tokens
+
+    @property
+    def tokenizer(self):
+        return self.processor.tokenizer
+
+    @property
+    def sampling_rate(self):
+        return self.processor.feature_extractor.sampling_rate
+
+    @property
+    def image_token_id(self):
+        return self.tokenizer.convert_tokens_to_ids(self.processor.image_token)
+
+    @property
+    def video_token_id(self):
+        return self.tokenizer.convert_tokens_to_ids(self.processor.video_token)
+
+    @property
+    def audio_token_id(self):
+        return self.tokenizer.convert_tokens_to_ids(self.processor.audio_token)
+
+    @property
+    def rt_start_id(self):
+        return self.tokenizer.convert_tokens_to_ids(self.processor.rt_start_token)
+
+    @property
+    def rt_pad_id(self):
+        return self.tokenizer.convert_tokens_to_ids(self.processor.rt_pad_token)
+
+    @property
+    def rt_speak_id(self):
+        return self.tokenizer.convert_tokens_to_ids(self.processor.rt_speak_token)
+
+    @property
+    def rt_end_id(self):
+        return self.tokenizer.convert_tokens_to_ids(self.processor.rt_end_token)
+
+    # ------------------------------------------------------------------
+    # Main process entry point
+    # ------------------------------------------------------------------
+
+    def process(
+        self,
+        images: Optional[List[Image]] = None,
+        hf_messages=None,
+        audios: Optional[List[np.ndarray]] = None,
+        sampling_rate: Optional[int] = None,
+        videos=None,
+        realtime_segments: Optional[List[Dict]] = None,
+        system_message: str = "You are a helpful assistant",
+        add_system_prompt=True,
+        **kwargs,
+    ):
+        """Process a single training example.
+
+        Args:
+            images: List of PIL images.
+            hf_messages: Messages in HF format (from convert_open_to_hf).
+                The ``realtime_text`` content items should already have been
+                stripped and passed via ``realtime_segments``.
+            audios: List of audio waveforms (mono, float32, at sampling_rate).
+            sampling_rate: Audio sampling rate.
+            videos: List of video frames (numpy arrays, TCHW format).
+            realtime_segments: List of ``{"start_sec": float, "text": str}``
+                dicts extracted from assistant ``realtime_text`` content items.
+                If None, this is treated as normal video QA.
+            system_message: System prompt text.
+            add_system_prompt: Whether to add a system prompt.
+            **kwargs: Forwarded to the model processor (e.g. ``fps``,
+                ``do_sample_frames``, ``video_metadata``).
+
+        Returns:
+            Dict with ``input_ids``, ``text_stream_ids``, ``labels``, and
+            vision/audio tensors.
+        """
+        output_kwargs = self.processor._merge_kwargs(
+            AeroRealtimeProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+
+        # ==============================================================
+        # 1. Process images
+        # ==============================================================
+        image_inputs = {}
+        image_grid_thw = None
+        if images is not None:
+            image_inputs = self.processor.image_processor(
+                images=images, return_tensors="pt", **output_kwargs.get("images_kwargs", {})
+            )
+            image_grid_thw = image_inputs["image_grid_thw"]
+
+        # ==============================================================
+        # 2. Process videos
+        # ==============================================================
+        video_inputs = {}
+        video_grid_thw = None
+        _video_metadata = None
+        if videos is not None:
+            videos_kwargs = output_kwargs.get("videos_kwargs", {})
+            video_inputs = self.processor.video_processor(videos=videos, return_tensors="pt", **videos_kwargs)
+            video_grid_thw = video_inputs["video_grid_thw"]
+            _video_metadata = video_inputs.pop("video_metadata")
+
+        # ==============================================================
+        # 3. Process audio
+        # ==============================================================
+        audio_inputs = {}
+        if audios is not None:
+            fe_kwargs = output_kwargs.get("audio_kwargs", {})
+            audio_inputs = self.processor.feature_extractor(
+                audios,
+                sampling_rate=sampling_rate or self.sampling_rate,
+                return_attention_mask=True,
+                padding="max_length",
+                return_tensors="pt",
+                **fe_kwargs,
+            )
+            audio_inputs["audio_attention_mask"] = audio_inputs.pop("attention_mask")
+
+        # ==============================================================
+        # 4. Compute token counts for placeholder expansion
+        # ==============================================================
+        if image_grid_thw is not None:
+            merge_length = self.processor.image_processor.merge_size**2
+            num_image_tokens = [int(grid_thw.prod() // merge_length) for grid_thw in image_grid_thw]
+        else:
+            num_image_tokens = None
+
+        if video_grid_thw is not None:
+            merge_length = self.processor.video_processor.merge_size**2
+            num_video_tokens = [int(grid_thw.prod() // merge_length) for grid_thw in video_grid_thw]
+        else:
+            num_video_tokens = None
+
+        has_video = video_grid_thw is not None
+        has_audio = bool(audio_inputs)
+
+        # Per-video audio token splits across video temporal chunks.
+        # Required for envelope construction when both video and audio are
+        # present (the inner ``<|audio_pad|>`` count of each per-chunk envelope).
+        audio_per_chunk_per_video = None
+        if has_video and has_audio:
+            mel_lengths = audio_inputs["audio_attention_mask"].sum(-1)
+            num_audio_tokens_list = [self.processor._get_num_audio_tokens(int(m.item())) for m in mel_lengths]
+            temporal_patch_size = getattr(self.processor.video_processor, "temporal_patch_size", 2)
+            audio_per_chunk_per_video = []
+            for v_idx in range(len(video_grid_thw)):
+                metadata = _video_metadata[v_idx]
+                fps = metadata.fps if metadata.fps is not None else 24.0
+                grid_t = int(video_grid_thw[v_idx][0])
+                curr_timestamp = self.processor._calculate_timestamps(
+                    metadata.frames_indices,
+                    fps,
+                    temporal_patch_size,
+                )
+                # Audio sample paired with this video by positional index
+                a_idx = v_idx if v_idx < len(num_audio_tokens_list) else 0
+                n_audio = num_audio_tokens_list[a_idx]
+                audio_duration = self.processor._get_audio_duration_seconds(audio_inputs["audio_attention_mask"][a_idx])
+                audio_rate = (n_audio / audio_duration) if audio_duration > 0 else 0.0
+                audio_per_chunk_per_video.append(
+                    self.processor._split_audio_across_chunk_times(
+                        n_audio=n_audio,
+                        chunk_start_times=curr_timestamp[:grid_t],
+                        audio_rate=audio_rate,
+                    )
+                )
+
+        # ==============================================================
+        # 5. Build input_ids, text_stream_ids, labels
+        # ==============================================================
+        if realtime_segments is None:
+            inputs = self._build_normal_qa_ids_and_labels(
+                hf_messages=hf_messages,
+                num_image_tokens=num_image_tokens,
+                num_video_tokens=num_video_tokens,
+                video_grid_thw=video_grid_thw,
+                video_metadata=_video_metadata,
+                audio_per_chunk_per_video=audio_per_chunk_per_video,
+                audio_attention_mask=audio_inputs.get("audio_attention_mask") if has_audio else None,
+                system_message=system_message,
+                add_system_prompt=add_system_prompt,
+            )
+        else:
+            inputs = self._build_realtime_ids_and_labels(
+                hf_messages=hf_messages,
+                num_image_tokens=num_image_tokens,
+                num_video_tokens=num_video_tokens,
+                video_grid_thw=video_grid_thw,
+                video_metadata=_video_metadata,
+                audio_per_chunk_per_video=audio_per_chunk_per_video,
+                audio_attention_mask=audio_inputs.get("audio_attention_mask") if has_audio else None,
+                realtime_segments=realtime_segments,
+                system_message=system_message,
+                add_system_prompt=add_system_prompt,
+            )
+
+        # ==============================================================
+        # 6. Pack vision/audio tensors into output
+        # ==============================================================
+        if images is not None:
+            inputs["pixel_values"] = image_inputs["pixel_values"]
+            inputs["image_grid_thw"] = image_inputs["image_grid_thw"]
+
+        if videos is not None:
+            for key, value in video_inputs.items():
+                inputs[key] = value
+
+        if audios is not None:
+            # Model expects `input_features` for audio
+            inputs["input_features"] = audio_inputs["input_features"]
+            inputs["audio_attention_mask"] = audio_inputs["audio_attention_mask"]
+
+        return inputs
+
+    # ------------------------------------------------------------------
+    # Core: build input_ids, text_stream_ids, labels
+    # ------------------------------------------------------------------
+
+    def _build_normal_qa_ids_and_labels(
+        self,
+        hf_messages,
+        num_image_tokens: Optional[List[int]],
+        num_video_tokens: Optional[List[int]],
+        video_grid_thw=None,
+        video_metadata=None,
+        audio_per_chunk_per_video: Optional[List[List[int]]] = None,
+        audio_attention_mask: Optional[torch.Tensor] = None,
+        realtime_segments: Optional[List[Dict]] = None,
+        system_message: str = "You are a helpful assistant",
+        add_system_prompt: bool = True,
+    ) -> dict:
+        """Build input_ids, text_stream_ids, and labels from HF messages.
+
+        For normal video QA the text_stream_ids only differ from input_ids
+        on audio pad positions, where all ``<|audio_pad|>`` slots become
+        ``<|rt_pad|>`` context. Normal QA keeps standard assistant labels;
+        realtime span labels are built by ``_build_realtime_ids_and_labels``.
+
+        Video placeholders and envelope boundary tokens keep their original
+        ids; vision features replace video placeholder embeddings in the model.
+        """
+        results = self.get_qwen_template_labels(
+            hf_messages,
+            num_image_tokens,
+            num_video_tokens,
+            video_metadata,
+            video_grid_thw,
+            audio_per_chunk_per_video=audio_per_chunk_per_video,
+            system_message=system_message,
+            add_system_prompt=add_system_prompt,
+        )
+        input_id = results["input_ids"].tolist()
+        target = results["labels"].tolist()
+
+        # ==============================================================
+        # Build text_stream_ids
+        # ==============================================================
+        has_video = video_grid_thw is not None
+        has_audio = audio_attention_mask is not None
+        text_stream_id = list(input_id)  # start as a copy of input_ids
+
+        if has_video and has_audio:
+            # video + audio: only audio pads carry realtime stream context
+            self.processor._fill_text_stream_video_audio(
+                stream=text_stream_id,
+                video_grid_thw=video_grid_thw,
+                video_metadata=video_metadata,
+                temporal_patch_size=getattr(self.processor.video_processor, "temporal_patch_size", 2),
+                audio_start_id=self.tokenizer.convert_tokens_to_ids(self.processor.audio_start_token),
+                audio_end_id=self.tokenizer.convert_tokens_to_ids(self.processor.audio_end_token),
+                rt_pad_id=self.rt_pad_id,
+            )
+        elif has_audio:
+            # audio-only: single envelope per audio sample
+            n_samples = audio_attention_mask.shape[0]
+            for s_idx in range(n_samples):
+                self.processor._fill_text_stream_audio_only(
+                    stream=text_stream_id,
+                    sample_idx=s_idx,
+                    audio_attention_mask=audio_attention_mask,
+                    audio_start_id=self.tokenizer.convert_tokens_to_ids(self.processor.audio_start_token),
+                    audio_end_id=self.tokenizer.convert_tokens_to_ids(self.processor.audio_end_token),
+                    audio_pad_id=self.audio_token_id,
+                    rt_start_id=self.rt_start_id,
+                    rt_pad_id=self.rt_pad_id,
+                    rt_speak_id=self.rt_speak_id,
+                )
+        # video-only (no audio): no text_stream_ids (matches processor)
+
+        input_id = torch.tensor(input_id, dtype=torch.long)
+        target = torch.tensor(target, dtype=torch.long)
+
+        result = dict(
+            input_ids=input_id,
+            labels=target,
+        )
+        # text_stream_ids only when audio is present (= streaming mode)
+        if has_audio:
+            result["text_stream_ids"] = torch.tensor(text_stream_id, dtype=torch.long)
+
+        return result
+
+    def _build_realtime_ids_and_labels(
+        self,
+        hf_messages,
+        num_image_tokens: Optional[List[int]],
+        num_video_tokens: Optional[List[int]],
+        video_grid_thw=None,
+        video_metadata=None,
+        audio_per_chunk_per_video: Optional[List[List[int]]] = None,
+        audio_attention_mask: Optional[torch.Tensor] = None,
+        realtime_segments: Optional[List[Dict]] = None,
+        system_message: str = "You are a helpful assistant",
+        add_system_prompt: bool = True,
+    ) -> dict:
+        if video_grid_thw is None or audio_per_chunk_per_video is None or audio_attention_mask is None:
+            raise ValueError("Realtime training requires both video and audio inputs.")
+
+        base_messages, timed_user_segments = self._build_realtime_base_messages(
+            hf_messages=hf_messages,
+            realtime_segments=realtime_segments or [],
+            video_grid_thw=video_grid_thw,
+            video_metadata=video_metadata,
+            audio_per_chunk_per_video=audio_per_chunk_per_video,
+            system_message=system_message,
+            add_system_prompt=add_system_prompt,
+        )
+
+        results = self.get_qwen_template_labels(
+            base_messages,
+            num_image_tokens,
+            num_video_tokens,
+            video_metadata,
+            video_grid_thw,
+            audio_per_chunk_per_video=audio_per_chunk_per_video,
+            timed_user_segments=timed_user_segments,
+            system_message=system_message,
+            add_system_prompt=False,
+        )
+        input_id = results["input_ids"].tolist()
+        text_stream_id = list(input_id)
+        target = [-100] * len(input_id)
+
+        self.processor._fill_text_stream_video_audio(
+            stream=text_stream_id,
+            video_grid_thw=video_grid_thw,
+            video_metadata=video_metadata,
+            temporal_patch_size=getattr(self.processor.video_processor, "temporal_patch_size", 2),
+            audio_start_id=self.tokenizer.convert_tokens_to_ids(self.processor.audio_start_token),
+            audio_end_id=self.tokenizer.convert_tokens_to_ids(self.processor.audio_end_token),
+            rt_pad_id=self.rt_pad_id,
+        )
+
+        audio_positions = [idx for idx, token_id in enumerate(input_id) if token_id == self.audio_token_id]
+        audio_times = self._get_audio_position_times(
+            video_grid_thw=video_grid_thw,
+            video_metadata=video_metadata,
+            audio_per_chunk_per_video=audio_per_chunk_per_video,
+        )
+        if len(audio_positions) != len(audio_times):
+            raise ValueError(f"Audio position/time mismatch: {len(audio_positions)} != {len(audio_times)}")
+
+        # Default supervision on every audio_pad slot: predict rt_pad (silence).
+        # Segments below overwrite this with text tokens where speech is happening.
+        for pos in audio_positions:
+            target[pos] = self.rt_pad_id
+
+        assistant_segments = sorted(
+            [seg for seg in (realtime_segments or []) if seg.get("role") == "assistant" and seg.get("text")],
+            key=lambda item: float(item["time"]),
+        )
+        occupied_audio_indices: set = set()
+        for segment in assistant_segments:
+            start_time = float(segment["time"])
+            start_audio_idx = self._first_index_at_or_after(audio_times, start_time)
+            available_indices = self._next_available_indices(
+                start=start_audio_idx,
+                count=len(audio_positions),
+                limit=len(audio_positions),
+                occupied=occupied_audio_indices,
+            )
+            if len(available_indices) < 2:
+                continue
+            # First slot holds rt_pad (unsupervised) so the next token has a
+            # context to attend to; remaining slots carry the speech tokens.
+            text_token_budget = len(available_indices) - 1
+            text_tokens = self._encode_realtime_text(segment["text"])[:text_token_budget]
+            # Write rt_pad in the first slot of this segment, but DO NOT
+            # supervise it (label stays at the default rt_pad set above? we
+            # want -100 so the model is never asked to "decide to start"
+            # against a boundary-aligned target).
+            first_audio_idx = available_indices[0]
+            first_pos = audio_positions[first_audio_idx]
+            text_stream_id[first_pos] = self.rt_pad_id
+            target[first_pos] = -100
+            occupied_audio_indices.add(first_audio_idx)
+            # Place speech tokens in the following slots; both stream and label
+            # carry the actual token id.
+            for audio_idx, token_id in zip(available_indices[1:], text_tokens):
+                pos = audio_positions[audio_idx]
+                text_stream_id[pos] = token_id
+                target[pos] = token_id
+                occupied_audio_indices.add(audio_idx)
+
+        input_tensor = torch.tensor(input_id, dtype=torch.long)
+        text_stream_tensor = torch.tensor(text_stream_id, dtype=torch.long)
+        target_tensor = torch.tensor(target, dtype=torch.long)
+
+        return dict(
+            input_ids=input_tensor,
+            labels=target_tensor,
+            text_stream_ids=text_stream_tensor,
+        )
+
+    def _build_realtime_base_messages(
+        self,
+        hf_messages,
+        realtime_segments: List[Dict],
+        video_grid_thw,
+        video_metadata,
+        audio_per_chunk_per_video: List[List[int]],
+        system_message: str,
+        add_system_prompt: bool,
+    ):
+        messages = []
+        first_content = []
+        timed_user_segments = sorted(
+            [seg for seg in realtime_segments if seg.get("role") == "user" and seg.get("text")],
+            key=lambda item: float(item["time"]),
+        )
+
+        if add_system_prompt and (not hf_messages or hf_messages[0]["role"] != "system"):
+            messages.append({"role": "system", "content": [{"type": "text", "text": system_message}]})
+
+        for message in hf_messages:
+            if message["role"] == "system":
+                messages.append(message)
+                continue
+            if message.get("time") is not None:
+                continue
+            for content in message["content"]:
+                if content.get("type") in ["image", "video", "audio"]:
+                    first_content.append(content)
+
+        content = []
+        content.extend(first_content)
+
+        messages.append({"role": "user", "content": content})
+        return messages, timed_user_segments
+
+    def _get_chunk_start_times(self, video_grid_thw, video_metadata, audio_per_chunk_per_video: List[List[int]]):
+        times = []
+        for v_idx in range(len(video_grid_thw)):
+            metadata = video_metadata[v_idx]
+            fps = metadata.fps if metadata.fps is not None else 24.0
+            curr_timestamp = self.processor._calculate_timestamps(
+                metadata.frames_indices,
+                fps,
+                self.processor.video_processor.temporal_patch_size,
+            )
+            for t in range(len(audio_per_chunk_per_video[v_idx])):
+                times.append(curr_timestamp[t] if t < len(curr_timestamp) else curr_timestamp[-1])
+        return times
+
+    def _get_audio_position_times(self, video_grid_thw, video_metadata, audio_per_chunk_per_video: List[List[int]]):
+        times = []
+        chunk_times = self._get_chunk_start_times(video_grid_thw, video_metadata, audio_per_chunk_per_video)
+        chunk_idx = 0
+        for audio_per_chunk in audio_per_chunk_per_video:
+            for n_audio in audio_per_chunk:
+                times.extend([chunk_times[chunk_idx]] * n_audio)
+                chunk_idx += 1
+        return times
+
+    def _encode_realtime_text(self, text: str) -> List[int]:
+        return self.tokenizer.encode(text, add_special_tokens=False)
+
+    @staticmethod
+    def _first_index_at_or_after(values: List[float], target: float) -> int:
+        for idx, value in enumerate(values):
+            if value >= target:
+                return idx
+        return len(values)
+
+    @staticmethod
+    def _next_available_indices(start: int, count: int, limit: int, occupied: set) -> List[int]:
+        indices = []
+        idx = start
+        while idx < limit and len(indices) < count:
+            if idx not in occupied:
+                indices.append(idx)
+            idx += 1
+        return indices
+
+    def get_qwen_template_labels(
+        self,
+        hf_messages,
+        num_image_tokens: List[int],
+        num_video_tokens: List[int],
+        video_metadata: List[dict],
+        video_grid_thw=None,
+        audio_per_chunk_per_video: Optional[List[List[int]]] = None,
+        timed_user_segments: Optional[List[Dict]] = None,
+        system_message: str = "You are a helpful assistant",
+        add_system_prompt: bool = True,
+        add_generation_prompt: bool = False,
+    ):
+        unmask_tokens_idx = [self.processor.tokenizer.convert_tokens_to_ids(t) for t in self.special_tokens]
+        input_id, target = [], []
+        image_start_from = 0
+        video_start_from = 0
+        if add_system_prompt and hf_messages[0]["role"] != "system":
+            input_id += DataUtilities.apply_chat_template(
+                self.processor, [{"role": "system", "content": [{"type": "text", "text": system_message}]}]
+            )
+            target += [-100] * len(input_id)
+        for message in hf_messages:
+            role = message["role"]
+            encode_id = DataUtilities.apply_chat_template(self.processor, [message])
+            # Should be 3 if instead of if else, so that can expand for each case
+            if self.image_token_id in encode_id:
+                encode_id, used_images = self._expand_encode_id_image_tokens(
+                    encode_id, num_image_tokens, image_start_from
+                )
+                image_start_from += used_images
+            if self.video_token_id in encode_id:
+                # Qwen3 VL new logic, build timestamp for different video frames
+                metadata = video_metadata[video_start_from]
+                if metadata.fps is None:
+                    metadata.fps = 24 if metadata.fps is None else metadata.fps
+                curr_timestamp = self.processor._calculate_timestamps(
+                    metadata.frames_indices,
+                    metadata.fps,
+                    self.processor.video_processor.temporal_patch_size,
+                )
+                encode_id, used_video = self._expand_encode_id_video_tokens(
+                    encode_id,
+                    num_video_tokens,
+                    video_start_from,
+                    curr_timestamp,
+                    video_grid_thw,
+                    audio_per_chunk_per_video=audio_per_chunk_per_video,
+                    timed_user_segments=timed_user_segments,
+                )
+                video_start_from += used_video
+
+            input_id += encode_id
+            if role in ["user", "system"]:
+                target += [-100] * len(encode_id)
+            else:
+                # Adopted from llava-ov that mask out the assistant
+                encode_id[:3] = [-100] * 3
+                target += encode_id
+
+        if add_generation_prompt:
+            generation_tokens = self.processor.tokenizer.encode("<|im_start|>assistant\n")
+            input_id += generation_tokens
+            target += [-100] * len(generation_tokens)
+        assert len(input_id) == len(target), f"{len(input_id)} != {len(target)}"
+        for idx, encode_id in enumerate(input_id):
+            if encode_id in unmask_tokens_idx:
+                target[idx] = encode_id
+            if encode_id == self.image_token_id:
+                target[idx] = -100
+            if encode_id == self.video_token_id:
+                target[idx] = -100
+            if encode_id == self.audio_token_id:
+                target[idx] = -100
+
+        input_id = torch.tensor(input_id, dtype=torch.long)
+        target = torch.tensor(target, dtype=torch.long)
+
+        return dict(
+            input_ids=input_id,
+            labels=target,
+        )
+
+    def _expand_encode_id_video_tokens(
+        self,
+        encode_id: List[int],
+        video_token_num: List[int],
+        start_from: int = 0,
+        curr_timestamp: List[float] = None,
+        video_grid_thw=None,
+        audio_per_chunk_per_video: Optional[List[List[int]]] = None,
+        timed_user_segments: Optional[List[Dict]] = None,
+    ):
+        """Expand ``<|video_pad|>`` placeholders.
+
+        - Without audio: per-frame Qwen3VL legacy expansion (delegated to
+          parent).
+        - With audio: per-chunk separated vision/audio envelopes::
+
+            <t.t seconds><|vision_start|><|video_pad|>×spatial<|vision_end|>
+            <|audio_start|><|audio_pad|>×N_t<|audio_end|>
+        """
+        if audio_per_chunk_per_video is None:
+            return super()._expand_encode_id_video_tokens(
+                encode_id, video_token_num, start_from, curr_timestamp, video_grid_thw
+            )
+
+        merge_length = self.processor.video_processor.merge_size**2
+        vision_start_id = self.processor.vision_start_token_id
+        vision_end_id = self.processor.vision_end_token_id
+        audio_start_id = self.tokenizer.convert_tokens_to_ids(self.processor.audio_start_token)
+        audio_end_id = self.tokenizer.convert_tokens_to_ids(self.processor.audio_end_token)
+        temporal_patch_size = getattr(self.processor.video_processor, "temporal_patch_size", 2)
+        timed_user_segments = timed_user_segments or []
+
+        video_pos = [i for i, x in enumerate(encode_id) if x == self.video_token_id]
+        expanded_encode_id = []
+        prev = 0
+        for idx, pos in enumerate(video_pos):
+            v_global = idx + start_from
+            grid = video_grid_thw[v_global]
+            grid_t = int(grid[0])
+            spatial = int(grid[1:].prod() // merge_length)
+
+            # Figure out per-chunk audio counts; fps from grid (we only have
+            # curr_timestamp which is per-frame timestamps in seconds).  Use
+            # them directly for the chunk start times.
+            audio_per_chunk = audio_per_chunk_per_video[v_global]
+            assert len(audio_per_chunk) == grid_t, f"audio_per_chunk len {len(audio_per_chunk)} != grid_t {grid_t}"
+            chunk_times = [
+                curr_timestamp[t] if t < len(curr_timestamp) else (t * temporal_patch_size) for t in range(grid_t)
+            ]
+            user_by_chunk = [[] for _ in range(grid_t)]
+            for segment in timed_user_segments:
+                chunk_idx = self._first_index_at_or_after(chunk_times, float(segment["time"]))
+                if chunk_idx >= grid_t:
+                    chunk_idx = grid_t - 1
+                user_by_chunk[chunk_idx].append(segment["text"])
+
+            # Strip surrounding <|vision_start|> / <|vision_end|> from the
+            # template (positions pos-1 and pos+1) -- we will emit our own.
+            expanded_encode_id.extend(encode_id[prev : pos - 1])
+
+            for t in range(grid_t):
+                for user_text in user_by_chunk[t]:
+                    expanded_encode_id.extend(self._encode_realtime_text(user_text))
+
+                # Per-frame timestamp (seconds) from the video metadata
+                t_sec = chunk_times[t]
+                timestamp_token_ids = self.processor.tokenizer.encode(f"<{t_sec:.1f} seconds>")
+                n_audio_t = audio_per_chunk[t]
+                expanded_encode_id.extend(timestamp_token_ids)
+                expanded_encode_id.append(vision_start_id)
+                expanded_encode_id.extend([self.video_token_id] * spatial)
+                expanded_encode_id.append(vision_end_id)
+                expanded_encode_id.append(audio_start_id)
+                expanded_encode_id.extend([self.audio_token_id] * n_audio_t)
+                expanded_encode_id.append(audio_end_id)
+
+            prev = pos + 2  # skip past original <|vision_end|>
+
+            if idx == len(video_pos) - 1:
+                expanded_encode_id.extend(encode_id[prev:])
+
+        return expanded_encode_id, len(video_pos)
+
+    # ------------------------------------------------------------------
+    # Chat template
+    # ------------------------------------------------------------------
+
+    @property
+    def chat_template(self):
+        """Chat template that handles realtime_text content by ignoring it.
+
+        Realtime text segments are extracted separately in the dataset
+        and passed as ``realtime_segments`` to the processor.  The chat
+        template only renders ``text``, ``image``, ``video``, and ``audio``
+        content types.
+        """
+        # fmt: off
+        return (
+            "{% set audio_count = namespace(value=0) %}"
+            "{% set image_count = namespace(value=0) %}"
+            "{% set video_count = namespace(value=0) %}"
+            "{% for message in messages %}"
+                "<|im_start|>{{ message['role'] }}\n"
+                "{% if message['content'] is string %}"
+                    "{{ message['content'] }}<|im_end|>\n"
+                "{% else %}"
+                    "{% for content in message['content'] %}"
+                        "{% if 'audio' in content or 'audio_url' in content %}"
+                            "{% set audio_count.value = audio_count.value + 1 %}"
+                            "<|audio_pad|>"
+                        "{% elif content['type'] == 'image' or 'image' in content or 'image_url' in content %}"
+                            "{% set image_count.value = image_count.value + 1 %}"
+                            "<|vision_start|><|image_pad|><|vision_end|>"
+                        "{% elif content['type'] == 'video' or 'video' in content %}"
+                            "{% set video_count.value = video_count.value + 1 %}"
+                            "<|vision_start|><|video_pad|><|vision_end|>"
+                        "{% elif 'text' in content %}"
+                            "{{ content['text'] }}"
+                        "{% elif content.get('type') == 'realtime_text' %}"
+                        "{% endif %}"
+                    "{% endfor %}"
+                    "<|im_end|>\n"
+                "{% endif %}"
+            "{% endfor %}"
+            "{% if add_generation_prompt %}"
+                "<|im_start|>assistant\n"
+            "{% endif %}"
+        )
+        # fmt: on

--- a/src/lmms_engine/datasets/processor/aero_realtime_processor.py
+++ b/src/lmms_engine/datasets/processor/aero_realtime_processor.py
@@ -213,7 +213,7 @@ class AeroRealtimeDataProcessor(Qwen3_VLDataProcessor):
                 audios,
                 sampling_rate=sampling_rate or self.sampling_rate,
                 return_attention_mask=True,
-                padding="max_length",
+                padding="longest",
                 return_tensors="pt",
                 **fe_kwargs,
             )
@@ -242,7 +242,13 @@ class AeroRealtimeDataProcessor(Qwen3_VLDataProcessor):
         # present (the inner ``<|audio_pad|>`` count of each per-chunk envelope).
         audio_per_chunk_per_video = None
         if has_video and has_audio:
-            mel_lengths = audio_inputs["audio_attention_mask"].sum(-1)
+            # FE attention_mask lags ``input_features`` by a small constant
+            # (reflection-pad frames at the mel boundary); add ``pad_offset``
+            # to recover the per-sample mel length before computing tokens.
+            mel_mask = audio_inputs["audio_attention_mask"]
+            T_mel = audio_inputs["input_features"].shape[-1]
+            pad_offset = max(0, T_mel - mel_mask.shape[-1])
+            mel_lengths = mel_mask.sum(-1).to(torch.long) + pad_offset
             num_audio_tokens_list = [self.processor._get_num_audio_tokens(int(m.item())) for m in mel_lengths]
             temporal_patch_size = getattr(self.processor.video_processor, "temporal_patch_size", 2)
             audio_per_chunk_per_video = []
@@ -311,7 +317,28 @@ class AeroRealtimeDataProcessor(Qwen3_VLDataProcessor):
         if audios is not None:
             # Model expects `input_features` for audio
             inputs["input_features"] = audio_inputs["input_features"]
-            inputs["audio_attention_mask"] = audio_inputs["audio_attention_mask"]
+            # Convert audio_attention_mask from mel-level (T_mel) to
+            # post-conv2 encoder length (T_enc = T_mel // 2) — what
+            # VoxtralRealtimeEncoder.forward expects. ``mel_mask`` from the
+            # FE lags ``input_features`` by ``pad_offset`` frames.
+            mel_mask = audio_inputs["audio_attention_mask"]
+            if not isinstance(mel_mask, torch.Tensor):
+                mel_mask = torch.as_tensor(mel_mask)
+            input_features = audio_inputs["input_features"]
+            if not isinstance(input_features, torch.Tensor):
+                input_features = torch.as_tensor(input_features)
+            T_mel = input_features.shape[-1]
+            pad_offset = max(0, T_mel - mel_mask.shape[-1])
+            mel_lengths_t = mel_mask.sum(-1).to(torch.long) + pad_offset
+            B = mel_mask.shape[0]
+            T_enc = T_mel // 2
+            enc_mask = torch.zeros(B, T_enc, dtype=torch.long)
+            for i in range(B):
+                m = min(int(mel_lengths_t[i].item()), T_mel)
+                enc_m = m // 2 if m > 0 else 0
+                if enc_m > 0:
+                    enc_mask[i, :enc_m] = 1
+            inputs["audio_attention_mask"] = enc_mask
 
         return inputs
 

--- a/src/lmms_engine/models/__init__.py
+++ b/src/lmms_engine/models/__init__.py
@@ -3,6 +3,12 @@ from lmms_engine.utils.import_utils import is_transformers_version_greater_or_eq
 is_transformers_5 = is_transformers_version_greater_or_equal_to("5.0.0")
 
 from .aero import AeroConfig, AeroForConditionalGeneration, AeroProcessor
+from .aero_realtime import (
+    AeroRealtimeConfig,
+    AeroRealtimeForConditionalGeneration,
+    AeroRealtimeProcessor,
+    apply_liger_kernel_to_aero_realtime,
+)
 from .bagel import Bagel, BagelConfig
 from .config import ModelConfig
 from .llava_onevision import apply_liger_kernel_to_llava_onevision
@@ -39,6 +45,10 @@ from .wanvideo import (
 __all__ = [
     "AeroForConditionalGeneration",
     "AeroConfig",
+    "AeroRealtimeConfig",
+    "AeroRealtimeForConditionalGeneration",
+    "AeroRealtimeProcessor",
+    "apply_liger_kernel_to_aero_realtime",
     "Bagel",
     "BagelConfig",
     "ModelConfig",

--- a/src/lmms_engine/models/aero_realtime/__init__.py
+++ b/src/lmms_engine/models/aero_realtime/__init__.py
@@ -1,7 +1,15 @@
+from transformers import AutoConfig, AutoModel
+
 from lmms_engine.mapping_func import register_model
 
-from .configuration_aero_realtime import AeroRealtimeConfig
-from .modeling_aero_realtime import AeroRealtimeForConditionalGeneration
+from .configuration_aero_realtime import (
+    AeroRealtimeAudioEncoderConfig,
+    AeroRealtimeConfig,
+)
+from .modeling_aero_realtime import (
+    AeroRealtimeAudioEncoder,
+    AeroRealtimeForConditionalGeneration,
+)
 from .monkey_patch import apply_liger_kernel_to_aero_realtime
 from .processing_aero_realtime import AeroRealtimeProcessor
 
@@ -11,9 +19,14 @@ register_model(
     AeroRealtimeForConditionalGeneration,
 )
 
+AutoConfig.register("aero_realtime_audio_encoder", AeroRealtimeAudioEncoderConfig, exist_ok=True)
+AutoModel.register(AeroRealtimeAudioEncoderConfig, AeroRealtimeAudioEncoder, exist_ok=True)
+
 __all__ = [
     "AeroRealtimeConfig",
+    "AeroRealtimeAudioEncoderConfig",
     "AeroRealtimeForConditionalGeneration",
+    "AeroRealtimeAudioEncoder",
     "AeroRealtimeProcessor",
     "apply_liger_kernel_to_aero_realtime",
 ]

--- a/src/lmms_engine/models/aero_realtime/__init__.py
+++ b/src/lmms_engine/models/aero_realtime/__init__.py
@@ -1,0 +1,19 @@
+from lmms_engine.mapping_func import register_model
+
+from .configuration_aero_realtime import AeroRealtimeConfig
+from .modeling_aero_realtime import AeroRealtimeForConditionalGeneration
+from .monkey_patch import apply_liger_kernel_to_aero_realtime
+from .processing_aero_realtime import AeroRealtimeProcessor
+
+register_model(
+    "aero_realtime",
+    AeroRealtimeConfig,
+    AeroRealtimeForConditionalGeneration,
+)
+
+__all__ = [
+    "AeroRealtimeConfig",
+    "AeroRealtimeForConditionalGeneration",
+    "AeroRealtimeProcessor",
+    "apply_liger_kernel_to_aero_realtime",
+]

--- a/src/lmms_engine/models/aero_realtime/aero_realtime_audio_ops.py
+++ b/src/lmms_engine/models/aero_realtime/aero_realtime_audio_ops.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
+from transformers.modeling_outputs import BaseModelOutputWithPooling
+from transformers.models.voxtral_realtime.modeling_voxtral_realtime import (
+    apply_rotary_pos_emb,
+)
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs
+
+from lmms_engine.kernels.attention import varlen_attn
+from lmms_engine.parallel.sequence_parallel.ulysses import (
+    gather_heads_scatter_seq,
+    gather_outputs_and_unpad,
+    gather_seq_scatter_heads,
+    get_ulysses_sequence_parallel_world_size,
+    slice_input_tensor,
+    validate_ulysses_config,
+)
+
+from .modeling_aero_realtime import (
+    AeroRealtimeAudioAttention,
+    AeroRealtimeAudioConv1dPaddingCache,
+    AeroRealtimeAudioEncoder,
+    AeroRealtimeAudioEncoderOutput,
+)
+
+
+def _get_unpad_data(attention_mask: torch.Tensor):
+    seqlens = attention_mask.sum(dim=-1, dtype=torch.int32)
+    indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
+    max_seqlen = seqlens.max().item()
+    cu_seqlens = F.pad(torch.cumsum(seqlens, dim=0, dtype=torch.int32), (1, 0))
+    return indices, cu_seqlens, max_seqlen
+
+
+def _pad_hidden_states(hidden_states: torch.Tensor, position_ids: torch.Tensor, sp_size: int):
+    pad_size = (sp_size - hidden_states.shape[0] % sp_size) % sp_size
+    if pad_size == 0:
+        return hidden_states, position_ids, pad_size
+
+    hidden_pad = hidden_states.new_zeros((pad_size, hidden_states.shape[-1]))
+    pos_pad = torch.arange(pad_size, dtype=position_ids.dtype, device=position_ids.device).unsqueeze(0)
+    return torch.cat([hidden_states, hidden_pad], dim=0), torch.cat([position_ids, pos_pad], dim=-1), pad_size
+
+
+def attention_forward(
+    self: AeroRealtimeAudioAttention,
+    hidden_states: torch.Tensor,
+    position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    attention_mask: torch.Tensor | None,
+    past_key_values: Cache | None = None,
+    **kwargs: Unpack[FlashAttentionKwargs],
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    assert isinstance(attention_mask, dict), "AeroRealtime rmpad attention requires packed attention metadata"
+    return _varlen_attention_forward(
+        self,
+        hidden_states=hidden_states,
+        position_embeddings=position_embeddings,
+        cu_seq_lens=attention_mask["cu_seq_lens"],
+        max_seqlen=attention_mask["max_seqlen"],
+    )
+
+
+def _varlen_attention_forward(
+    self: AeroRealtimeAudioAttention,
+    hidden_states: torch.Tensor,
+    position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    cu_seq_lens: torch.Tensor,
+    max_seqlen: int,
+) -> tuple[torch.Tensor, None]:
+    sp_size = get_ulysses_sequence_parallel_world_size()
+    total = hidden_states.shape[0]
+    query_states = self.q_proj(hidden_states).view(total, self.config.num_attention_heads, self.head_dim)
+    key_states = self.k_proj(hidden_states).view(total, self.config.num_key_value_heads, self.head_dim)
+    value_states = self.v_proj(hidden_states).view(total, self.config.num_key_value_heads, self.head_dim)
+
+    cos, sin = position_embeddings
+    query_states = query_states.transpose(0, 1).unsqueeze(0)
+    key_states = key_states.transpose(0, 1).unsqueeze(0)
+    query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+    query_states = query_states.squeeze(0).transpose(0, 1).contiguous()
+    key_states = key_states.squeeze(0).transpose(0, 1).contiguous()
+
+    if sp_size > 1:
+        validate_ulysses_config(query_states.size(1), sp_size)
+        query_states = gather_seq_scatter_heads(query_states, seq_dim=0, head_dim=1)
+        key_states = gather_seq_scatter_heads(key_states, seq_dim=0, head_dim=1)
+        value_states = gather_seq_scatter_heads(value_states, seq_dim=0, head_dim=1)
+
+    window_left = int(getattr(self.config, "attention_window_left", -1))
+    window_right = int(getattr(self.config, "attention_window_right", -1))
+    window_size = (window_left, window_right)
+    attn_output = varlen_attn(
+        query_states,
+        key_states,
+        value_states,
+        cu_seqlens_q=cu_seq_lens,
+        cu_seqlens_k=cu_seq_lens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_k=max_seqlen,
+        causal=True,
+        softmax_scale=self.scaling,
+        window_size=window_size,
+        dropout_p=0.0 if not self.training else self.attention_dropout,
+        backend=self.config._attn_implementation,
+    )
+    if sp_size > 1:
+        attn_output = gather_heads_scatter_seq(attn_output, seq_dim=0, head_dim=1)
+
+    attn_output = self.o_proj(attn_output.reshape(total, -1))
+    return attn_output, None
+
+
+def encoder_forward(
+    self: AeroRealtimeAudioEncoder,
+    input_features: torch.FloatTensor | None = None,
+    position_ids: torch.LongTensor | None = None,
+    past_key_values: Cache | None = None,
+    padding_cache: AeroRealtimeAudioConv1dPaddingCache | None = None,
+    inputs_embeds: torch.FloatTensor | None = None,
+    use_cache: bool | None = None,
+    use_padding_cache: bool | None = None,
+    attention_mask: torch.Tensor | None = None,
+    **kwargs: Unpack[TransformersKwargs],
+) -> tuple | BaseModelOutputWithPooling:
+    if (input_features is None) ^ (inputs_embeds is not None):
+        raise ValueError("You must specify exactly one of input_features or inputs_embeds")
+
+    if use_padding_cache and padding_cache is None:
+        padding_cache = AeroRealtimeAudioConv1dPaddingCache()
+
+    if inputs_embeds is None:
+        inputs_embeds = self.embedder(input_features, padding_cache)
+
+    if use_cache and past_key_values is None:
+        past_key_values = DynamicCache(config=self.config)
+
+    if position_ids is None:
+        past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+        position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+        position_ids = position_ids.unsqueeze(0)
+
+    hidden_states = inputs_embeds
+    if attention_mask is None:
+        attention_mask = torch.ones(inputs_embeds.shape[:2], dtype=torch.long, device=inputs_embeds.device)
+    indices, cu_seq_lens, max_seqlen = _get_unpad_data(attention_mask)
+    hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])[indices]
+    position_ids = position_ids.expand(inputs_embeds.shape[0], -1).reshape(-1)[indices].unsqueeze(0)
+    sp_size = get_ulysses_sequence_parallel_world_size()
+    pad_size = 0
+    if sp_size > 1:
+        hidden_states, position_ids, pad_size = _pad_hidden_states(hidden_states, position_ids, sp_size)
+        hidden_states = slice_input_tensor(hidden_states, dim=0, padding=False)
+        position_ids = slice_input_tensor(position_ids, dim=-1, padding=False)
+        if pad_size > 0:
+            cu_seq_lens = torch.cat([cu_seq_lens, cu_seq_lens.new_tensor([cu_seq_lens[-1].item() + pad_size])])
+    causal_mask = {
+        "cu_seq_lens": cu_seq_lens,
+        "max_seqlen": max_seqlen,
+    }
+    position_embeddings = self.rotary_emb(hidden_states, position_ids=position_ids)
+
+    for encoder_layer in self.layers:
+        hidden_states = encoder_layer(
+            hidden_states,
+            attention_mask=causal_mask,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            **kwargs,
+        )
+
+    hidden_states = self.norm(hidden_states)
+    if sp_size > 1:
+        hidden_states = gather_outputs_and_unpad(hidden_states, gather_dim=0, unpad_dim=0, padding_size=pad_size)
+
+    return AeroRealtimeAudioEncoderOutput(
+        last_hidden_state=hidden_states,
+        past_key_values=past_key_values,
+        padding_cache=padding_cache,
+    )
+
+
+aero_realtime_attention_forward = attention_forward
+aero_realtime_encoder_forward = encoder_forward
+
+__all__ = [
+    "attention_forward",
+    "encoder_forward",
+    "aero_realtime_attention_forward",
+    "aero_realtime_encoder_forward",
+]

--- a/src/lmms_engine/models/aero_realtime/aero_realtime_audio_ops.py
+++ b/src/lmms_engine/models/aero_realtime/aero_realtime_audio_ops.py
@@ -102,7 +102,7 @@ def _varlen_attention_forward(
         cu_seqlens_k=cu_seq_lens,
         max_seqlen_q=max_seqlen,
         max_seqlen_k=max_seqlen,
-        causal=True,
+        causal=bool(getattr(self.config, "is_causal", False)),
         softmax_scale=self.scaling,
         window_size=window_size,
         dropout_p=0.0 if not self.training else self.attention_dropout,

--- a/src/lmms_engine/models/aero_realtime/aero_realtime_liger.py
+++ b/src/lmms_engine/models/aero_realtime/aero_realtime_liger.py
@@ -181,6 +181,8 @@ def aero_realtime_lce_forward(
     # ---- 2. Embedding on packed ids ----
     if inputs_embeds is None:
         inputs_embeds = self.get_input_embeddings()(embed_ids)
+    elif pixel_values is not None or pixel_values_videos is not None or input_features is not None:
+        inputs_embeds = inputs_embeds.clone()
 
     # ---- 3. Image features — scatter into packed embeddings ----
     image_features = None
@@ -193,10 +195,7 @@ def aero_realtime_lce_forward(
             raise ValueError(
                 f"Image token count ({n_image_tokens}) does not match " f"image feature count ({n_image_features})."
             )
-        inputs_embeds = inputs_embeds.masked_scatter(
-            image_mask.unsqueeze(-1).expand_as(inputs_embeds),
-            image_features.to(inputs_embeds.dtype),
-        )
+        inputs_embeds[image_mask] = image_features.to(inputs_embeds.dtype)
 
     # ---- 4. Video features — scatter into packed embeddings ----
     video_features = None
@@ -209,10 +208,7 @@ def aero_realtime_lce_forward(
             raise ValueError(
                 f"Video token count ({n_video_tokens}) does not match " f"video feature count ({n_video_features})."
             )
-        inputs_embeds = inputs_embeds.masked_scatter(
-            video_mask.unsqueeze(-1).expand_as(inputs_embeds),
-            video_features.to(inputs_embeds.dtype),
-        )
+        inputs_embeds[video_mask] = video_features.to(inputs_embeds.dtype)
 
     # ---- 5. Audio features — add into packed embeddings ----
     audio_features_flat = None
@@ -231,7 +227,6 @@ def aero_realtime_lce_forward(
             raise ValueError(
                 f"Audio token count ({n_audio_tokens}) does not match " f"audio feature count ({n_audio_features})."
             )
-        inputs_embeds = inputs_embeds.clone()
         inputs_embeds[audio_mask] = inputs_embeds[audio_mask] + audio_features_flat.to(inputs_embeds.dtype)
 
     # 7d. Unpad labels

--- a/src/lmms_engine/models/aero_realtime/aero_realtime_liger.py
+++ b/src/lmms_engine/models/aero_realtime/aero_realtime_liger.py
@@ -43,6 +43,51 @@ except Exception:
     _HAS_LIGER = False
 
 
+def _get_audio_features_rmpad(self, input_features: torch.Tensor, audio_attention_mask: Optional[torch.Tensor]):
+    audio_outputs = self.audio_tower(
+        input_features=input_features,
+        attention_mask=audio_attention_mask,
+    )
+    if isinstance(audio_outputs, torch.Tensor):
+        audio_hidden_states = audio_outputs
+    else:
+        audio_hidden_states = audio_outputs.last_hidden_state
+
+    df = self.config.downsample_factor
+    audio_output_lengths = None
+    if audio_attention_mask is not None:
+        audio_output_lengths = audio_attention_mask.sum(-1) // df
+
+    if audio_hidden_states.dim() == 2:
+        if audio_attention_mask is None:
+            raise ValueError("Packed audio hidden states require audio_attention_mask.")
+
+        chunks = []
+        offset = 0
+        for length in audio_attention_mask.sum(-1).tolist():
+            usable_len = (length // df) * df
+            if usable_len > 0:
+                chunk = audio_hidden_states[offset : offset + usable_len]
+                chunks.append(chunk.reshape(-1, self.config.audio_hidden_size * df))
+            offset += length
+
+        if chunks:
+            audio_hidden_states = torch.cat(chunks, dim=0)
+        else:
+            audio_hidden_states = audio_hidden_states.new_empty((0, self.config.audio_hidden_size * df))
+    else:
+        seq_len = audio_hidden_states.shape[1]
+        usable_len = (seq_len // df) * df
+        audio_hidden_states = audio_hidden_states[:, :usable_len, :]
+        audio_hidden_states = audio_hidden_states.reshape(
+            audio_hidden_states.shape[0],
+            -1,
+            self.config.audio_hidden_size * df,
+        )
+
+    return self.multi_modal_projector(audio_hidden_states), audio_output_lengths
+
+
 def aero_realtime_lce_forward(
     self,  # AeroRealtimeForConditionalGeneration
     input_ids: Optional[torch.LongTensor] = None,
@@ -172,10 +217,10 @@ def aero_realtime_lce_forward(
     # ---- 5. Audio features — add into packed embeddings ----
     audio_features_flat = None
     if input_features is not None:
-        audio_features, audio_output_lengths = self.get_audio_features(
-            input_features, audio_attention_mask=audio_attention_mask
-        )
-        if audio_output_lengths is not None:
+        audio_features, audio_output_lengths = _get_audio_features_rmpad(self, input_features, audio_attention_mask)
+        if audio_features.dim() == 2:
+            audio_features_flat = audio_features
+        elif audio_output_lengths is not None:
             audio_features_flat = self._unpad_audio_features(audio_features, audio_output_lengths)
         else:
             audio_features_flat = audio_features.reshape(-1, audio_features.shape[-1])

--- a/src/lmms_engine/models/aero_realtime/aero_realtime_liger.py
+++ b/src/lmms_engine/models/aero_realtime/aero_realtime_liger.py
@@ -83,84 +83,12 @@ def aero_realtime_lce_forward(
     return_dict = return_dict if return_dict is not None else self.config.use_return_dict
     sp_size = get_ulysses_sequence_parallel_world_size()
 
-    # ---- 1. Embedding (same as original) ----
-    embed_ids = text_stream_ids if text_stream_ids is not None else input_ids
-
-    if inputs_embeds is None:
-        inputs_embeds = self.get_input_embeddings()(embed_ids)
-
-    # Keep original input_ids for mask computation (before unpadding)
+    # Keep original input_ids for mrope + modality placeholder masks.
     original_input_ids = input_ids
     batch_size, seq_length = original_input_ids.shape
 
-    # ---- 2. Image features — scatter (same as original) ----
-    if pixel_values is not None:
-        image_features = self.get_vision_features(pixel_values, grid_thw=image_grid_thw)
-        image_mask = original_input_ids == self.config.image_token_index
-        n_image_tokens = image_mask.sum().item()
-        n_image_features = image_features.shape[0]
-        if n_image_tokens != n_image_features:
-            raise ValueError(
-                f"Image token count ({n_image_tokens}) does not match " f"image feature count ({n_image_features})."
-            )
-        image_mask_expanded = image_mask.unsqueeze(-1).expand_as(inputs_embeds)
-        inputs_embeds = inputs_embeds.masked_scatter(
-            image_mask_expanded,
-            image_features.to(inputs_embeds.dtype),
-        )
-
-    # ---- 3. Video features ----
-    video_features = None
-    if pixel_values_videos is not None:
-        video_features = self.get_vision_features(pixel_values_videos, grid_thw=video_grid_thw)
-
-    # ---- 4. Audio features ----
-    audio_features = None
-    audio_features_flat = None
-    if input_features is not None:
-        audio_features, audio_output_lengths = self.get_audio_features(
-            input_features, audio_attention_mask=audio_attention_mask
-        )
-        if audio_output_lengths is not None:
-            audio_features_flat = self._unpad_audio_features(audio_features, audio_output_lengths)
-        else:
-            audio_features_flat = audio_features.reshape(-1, audio_features.shape[-1])
-
-    # ---- 5. Scatter video features and add audio features ----
-
-    # 5a. Scatter video features at video_token_index positions
-    if video_features is not None:
-        video_mask = original_input_ids == self.config.video_token_index
-        n_video_tokens = video_mask.sum().item()
-        n_video_features = video_features.shape[0]
-        if n_video_tokens != n_video_features:
-            raise ValueError(
-                f"Video token count ({n_video_tokens}) does not match " f"video feature count ({n_video_features})."
-            )
-        video_mask_expanded = video_mask.unsqueeze(-1).expand_as(inputs_embeds)
-        inputs_embeds = inputs_embeds.masked_scatter(
-            video_mask_expanded,
-            video_features.to(inputs_embeds.dtype),
-        )
-
-    # 5b. Add audio features at audio_token_index positions
-    if audio_features_flat is not None:
-        audio_mask = original_input_ids == self.config.audio_token_index
-        n_audio_tokens = audio_mask.sum().item()
-        n_audio_features = audio_features_flat.shape[0]
-        if n_audio_tokens != n_audio_features:
-            raise ValueError(
-                f"Audio token count ({n_audio_tokens}) does not match " f"audio feature count ({n_audio_features})."
-            )
-        audio_mask_flat = audio_mask.reshape(-1)
-        inputs_embeds_flat = inputs_embeds.reshape(-1, inputs_embeds.shape[-1])
-        inputs_embeds_flat[audio_mask_flat] = inputs_embeds_flat[audio_mask_flat] + audio_features_flat.to(
-            inputs_embeds.dtype
-        )
-        inputs_embeds = inputs_embeds_flat.reshape(inputs_embeds.shape)
-
     # ==================================================================
-    # RMPad: unpad + position_ids (mirrors qwen3_vl_ops.model_forward)
+    # RMPad first, then modality injection (mirrors qwen3_5_ops.model_forward)
     # ==================================================================
 
     # 7a. Compute position_ids using qwen3_vl_get_rope_index
@@ -175,8 +103,14 @@ def aero_realtime_lce_forward(
             attention_mask=attention_mask,
         )
 
-    # 7b. Unpad inputs_embeds
-    inputs_embeds, indices, cu_seq_lens, _ = _unpad_input(inputs_embeds, attention_mask=attention_mask)
+    # 7b. Unpad input_ids and text_stream_ids. We scatter modalities on the
+    # packed layout, matching qwen3_5_ops.model_forward. This keeps the
+    # vit_frame_parallel autograd collective path identical to the base model.
+    input_ids, indices, cu_seq_lens, _ = _unpad_input(input_ids, attention_mask=attention_mask)
+    if text_stream_ids is not None:
+        embed_ids = text_stream_ids.reshape(-1)[indices]
+    else:
+        embed_ids = input_ids
 
     # 7c. Unpad position_ids: [3, B, S] -> index by valid positions -> [3, 1, total_tokens]
     position_ids = (
@@ -184,21 +118,81 @@ def aero_realtime_lce_forward(
     )
 
     # Qwen3VLTextModel's Ulysses wrapper pads/slices inputs_embeds before the
-    # text forward. Pad global position_ids to the same padded length so RoPE
-    # cos/sin length matches q/k after all-to-all when total tokens is odd.
+    # text forward. We mirror qwen3_5_ops.model_forward: pad the packed seq
+    # to a multiple of sp_size and mark the pad span as its own sample in
+    # ``cu_seq_lens`` so linear-attn / causal-conv don't leak the pad region
+    # back into the real tail sample (full-attn doesn't care because pad
+    # tokens are loss-masked anyway).
+    pad_size = 0
     if sp_size > 1:
-        dummy_ids = torch.zeros(
-            (1, inputs_embeds.shape[0]),
-            dtype=torch.long,
-            device=inputs_embeds.device,
+        input_ids, position_ids, pad_size = ulysses_pad(input_ids.unsqueeze(0), position_ids, sp_size=sp_size)
+        input_ids = input_ids.squeeze(0)
+        if pad_size > 0:
+            embed_ids = torch.nn.functional.pad(embed_ids, (0, pad_size), value=self.config.rt_pad_token_index)
+            # Mark pad span as its own sample so linear-attn / causal-conv
+            # don't see it as a continuation of the last real sample.
+            cu_seq_lens = torch.cat([cu_seq_lens, cu_seq_lens.new_tensor([cu_seq_lens[-1].item() + pad_size])])
+
+    # ---- 2. Embedding on packed ids ----
+    if inputs_embeds is None:
+        inputs_embeds = self.get_input_embeddings()(embed_ids)
+
+    # ---- 3. Image features — scatter into packed embeddings ----
+    image_features = None
+    if pixel_values is not None:
+        image_features = self.get_vision_features(pixel_values, grid_thw=image_grid_thw)
+        image_mask = input_ids == self.config.image_token_index
+        n_image_tokens = image_mask.sum().item()
+        n_image_features = image_features.shape[0]
+        if n_image_tokens != n_image_features:
+            raise ValueError(
+                f"Image token count ({n_image_tokens}) does not match " f"image feature count ({n_image_features})."
+            )
+        inputs_embeds = inputs_embeds.masked_scatter(
+            image_mask.unsqueeze(-1).expand_as(inputs_embeds),
+            image_features.to(inputs_embeds.dtype),
         )
-        _, position_ids, _ = ulysses_pad(dummy_ids, position_ids, sp_size=sp_size)
+
+    # ---- 4. Video features — scatter into packed embeddings ----
+    video_features = None
+    if pixel_values_videos is not None:
+        video_features = self.get_vision_features(pixel_values_videos, grid_thw=video_grid_thw)
+        video_mask = input_ids == self.config.video_token_index
+        n_video_tokens = video_mask.sum().item()
+        n_video_features = video_features.shape[0]
+        if n_video_tokens != n_video_features:
+            raise ValueError(
+                f"Video token count ({n_video_tokens}) does not match " f"video feature count ({n_video_features})."
+            )
+        inputs_embeds = inputs_embeds.masked_scatter(
+            video_mask.unsqueeze(-1).expand_as(inputs_embeds),
+            video_features.to(inputs_embeds.dtype),
+        )
+
+    # ---- 5. Audio features — add into packed embeddings ----
+    audio_features_flat = None
+    if input_features is not None:
+        audio_features, audio_output_lengths = self.get_audio_features(
+            input_features, audio_attention_mask=audio_attention_mask
+        )
+        if audio_output_lengths is not None:
+            audio_features_flat = self._unpad_audio_features(audio_features, audio_output_lengths)
+        else:
+            audio_features_flat = audio_features.reshape(-1, audio_features.shape[-1])
+        audio_mask = input_ids == self.config.audio_token_index
+        n_audio_tokens = audio_mask.sum().item()
+        n_audio_features = audio_features_flat.shape[0]
+        if n_audio_tokens != n_audio_features:
+            raise ValueError(
+                f"Audio token count ({n_audio_tokens}) does not match " f"audio feature count ({n_audio_features})."
+            )
+        inputs_embeds = inputs_embeds.clone()
+        inputs_embeds[audio_mask] = inputs_embeds[audio_mask] + audio_features_flat.to(inputs_embeds.dtype)
 
     # 7d. Unpad labels
     if labels is not None:
         labels_unpad = labels.view(-1)[indices]
         if sp_size > 1:
-            pad_size = (sp_size - labels_unpad.shape[0] % sp_size) % sp_size
             if pad_size > 0:
                 labels_unpad = torch.nn.functional.pad(labels_unpad, (0, pad_size), value=-100)
             labels_unpad = slice_input_tensor(labels_unpad, dim=0, padding=False)

--- a/src/lmms_engine/models/aero_realtime/aero_realtime_liger.py
+++ b/src/lmms_engine/models/aero_realtime/aero_realtime_liger.py
@@ -54,6 +54,7 @@ def _get_audio_features_rmpad(self, input_features: torch.Tensor, audio_attentio
         audio_hidden_states = audio_outputs.last_hidden_state
 
     df = self.config.downsample_factor
+    H = self.config.audio_hidden_size
     audio_output_lengths = None
     if audio_attention_mask is not None:
         audio_output_lengths = audio_attention_mask.sum(-1) // df
@@ -62,19 +63,37 @@ def _get_audio_features_rmpad(self, input_features: torch.Tensor, audio_attentio
         if audio_attention_mask is None:
             raise ValueError("Packed audio hidden states require audio_attention_mask.")
 
-        chunks = []
-        offset = 0
-        for length in audio_attention_mask.sum(-1).tolist():
-            usable_len = (length // df) * df
-            if usable_len > 0:
-                chunk = audio_hidden_states[offset : offset + usable_len]
-                chunks.append(chunk.reshape(-1, self.config.audio_hidden_size * df))
-            offset += length
+        B, max_T = audio_attention_mask.shape
+        total_valid = audio_hidden_states.shape[0]
 
-        if chunks:
-            audio_hidden_states = torch.cat(chunks, dim=0)
+        # Fast path: every row of audio_attention_mask is fully valid AND
+        # max_T is divisible by df. This is the dominant case under chunked
+        # streaming training (each chunk produces exactly df encoder frames),
+        # and lets us skip the per-segment python loop + cat in the slow path.
+        if max_T % df == 0 and total_valid == B * max_T:
+            audio_hidden_states = audio_hidden_states.reshape(-1, H * df)
         else:
-            audio_hidden_states = audio_hidden_states.new_empty((0, self.config.audio_hidden_size * df))
+            # Slow path: ragged segments. Build a fully-GPU gather index that
+            # selects only the `usable_len = (length // df) * df` rows from
+            # each segment, then reshape in one shot. Avoids the python loop
+            # + per-chunk slice + cat over potentially thousands of segments.
+            lengths = audio_attention_mask.sum(-1)
+            usable_lens = (lengths // df) * df
+            total_usable = int(usable_lens.sum().item())
+            if total_usable == 0:
+                audio_hidden_states = audio_hidden_states.new_empty((0, H * df))
+            else:
+                in_starts = torch.cumsum(lengths, dim=0) - lengths
+                out_starts = torch.cumsum(usable_lens, dim=0) - usable_lens
+                flat = torch.arange(total_usable, device=lengths.device)
+                seg = torch.searchsorted(
+                    out_starts[1:].contiguous() if B > 1 else out_starts.new_zeros(0),
+                    flat,
+                    right=True,
+                )
+                gather_idx = flat + (in_starts - out_starts)[seg]
+                audio_hidden_states = audio_hidden_states.index_select(0, gather_idx)
+                audio_hidden_states = audio_hidden_states.reshape(-1, H * df)
     else:
         seq_len = audio_hidden_states.shape[1]
         usable_len = (seq_len // df) * df
@@ -82,7 +101,7 @@ def _get_audio_features_rmpad(self, input_features: torch.Tensor, audio_attentio
         audio_hidden_states = audio_hidden_states.reshape(
             audio_hidden_states.shape[0],
             -1,
-            self.config.audio_hidden_size * df,
+            H * df,
         )
 
     return self.multi_modal_projector(audio_hidden_states), audio_output_lengths

--- a/src/lmms_engine/models/aero_realtime/aero_realtime_liger.py
+++ b/src/lmms_engine/models/aero_realtime/aero_realtime_liger.py
@@ -1,0 +1,282 @@
+"""RMPad + LigerCE forward for AeroRealtime.
+
+Mirrors what ``qwen3_vl_ops.model_forward`` does for ``Qwen3VLModel``:
+  1. Compute position_ids via ``qwen3_vl_get_rope_index``
+  2. Unpad inputs_embeds, position_ids, labels with ``_unpad_input``
+  3. Pass ``indices`` and ``cu_seq_lens`` to the language model
+  4. Use ``LigerFusedLinearCrossEntropyLoss`` for memory-efficient loss
+
+This function replaces ``AeroRealtimeForConditionalGeneration.forward``
+when rmpad is enabled via the monkey patch system.
+"""
+
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.distributed as dist
+from torch import nn
+from transformers.utils import is_flash_attn_2_available
+
+from lmms_engine.parallel.sequence_parallel.ulysses import (
+    calculate_seq_len_per_rank,
+    gather_outputs_and_unpad,
+    get_ulysses_sequence_parallel_group,
+    get_ulysses_sequence_parallel_world_size,
+    pad_to_max_across_ranks,
+    slice_input_tensor,
+    ulysses_pad,
+)
+
+from ..common_ops.rope import qwen3_vl_get_rope_index
+from ..sequence_packing_utils import _unpad_input
+
+if is_flash_attn_2_available():
+    from flash_attn.bert_padding import index_first_axis, rearrange
+
+try:
+    from liger_kernel.transformers.fused_linear_cross_entropy import (
+        LigerFusedLinearCrossEntropyLoss,
+    )
+
+    _HAS_LIGER = True
+except Exception:
+    _HAS_LIGER = False
+
+
+def aero_realtime_lce_forward(
+    self,  # AeroRealtimeForConditionalGeneration
+    input_ids: Optional[torch.LongTensor] = None,
+    text_stream_ids: Optional[torch.LongTensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[List[torch.FloatTensor]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    # Audio inputs
+    input_features: Optional[torch.FloatTensor] = None,
+    audio_attention_mask: Optional[torch.Tensor] = None,
+    # Vision inputs — images
+    pixel_values: Optional[torch.FloatTensor] = None,
+    image_grid_thw: Optional[torch.LongTensor] = None,
+    # Vision inputs — videos
+    pixel_values_videos: Optional[torch.FloatTensor] = None,
+    video_grid_thw: Optional[torch.LongTensor] = None,
+    # Standard args
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+    **kwargs,
+):
+    """RMPad-aware forward for AeroRealtime with LigerCE loss.
+
+    Same pipeline as the original forward (embed → scatter vision → add audio
+    on audio token positions — realtime conditioning lives on the audio
+    timeline).
+    Adds:
+    - Proper mrope position_ids via ``qwen3_vl_get_rope_index``
+    - Unpadding of inputs_embeds/position_ids/labels before the language model
+    - ``LigerFusedLinearCrossEntropyLoss`` instead of materializing full logits
+    """
+    from .modeling_aero_realtime import AeroRealtimeCausalLMOutputWithPast
+
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+    sp_size = get_ulysses_sequence_parallel_world_size()
+
+    # ---- 1. Embedding (same as original) ----
+    embed_ids = text_stream_ids if text_stream_ids is not None else input_ids
+
+    if inputs_embeds is None:
+        inputs_embeds = self.get_input_embeddings()(embed_ids)
+
+    # Keep original input_ids for mask computation (before unpadding)
+    original_input_ids = input_ids
+    batch_size, seq_length = original_input_ids.shape
+
+    # ---- 2. Image features — scatter (same as original) ----
+    if pixel_values is not None:
+        image_features = self.get_vision_features(pixel_values, grid_thw=image_grid_thw)
+        image_mask = original_input_ids == self.config.image_token_index
+        n_image_tokens = image_mask.sum().item()
+        n_image_features = image_features.shape[0]
+        if n_image_tokens != n_image_features:
+            raise ValueError(
+                f"Image token count ({n_image_tokens}) does not match " f"image feature count ({n_image_features})."
+            )
+        image_mask_expanded = image_mask.unsqueeze(-1).expand_as(inputs_embeds)
+        inputs_embeds = inputs_embeds.masked_scatter(
+            image_mask_expanded,
+            image_features.to(inputs_embeds.dtype),
+        )
+
+    # ---- 3. Video features ----
+    video_features = None
+    if pixel_values_videos is not None:
+        video_features = self.get_vision_features(pixel_values_videos, grid_thw=video_grid_thw)
+
+    # ---- 4. Audio features ----
+    audio_features = None
+    audio_features_flat = None
+    if input_features is not None:
+        audio_features, audio_output_lengths = self.get_audio_features(
+            input_features, audio_attention_mask=audio_attention_mask
+        )
+        if audio_output_lengths is not None:
+            audio_features_flat = self._unpad_audio_features(audio_features, audio_output_lengths)
+        else:
+            audio_features_flat = audio_features.reshape(-1, audio_features.shape[-1])
+
+    # ---- 5. Scatter video features and add audio features ----
+
+    # 5a. Scatter video features at video_token_index positions
+    if video_features is not None:
+        video_mask = original_input_ids == self.config.video_token_index
+        n_video_tokens = video_mask.sum().item()
+        n_video_features = video_features.shape[0]
+        if n_video_tokens != n_video_features:
+            raise ValueError(
+                f"Video token count ({n_video_tokens}) does not match " f"video feature count ({n_video_features})."
+            )
+        video_mask_expanded = video_mask.unsqueeze(-1).expand_as(inputs_embeds)
+        inputs_embeds = inputs_embeds.masked_scatter(
+            video_mask_expanded,
+            video_features.to(inputs_embeds.dtype),
+        )
+
+    # 5b. Add audio features at audio_token_index positions
+    if audio_features_flat is not None:
+        audio_mask = original_input_ids == self.config.audio_token_index
+        n_audio_tokens = audio_mask.sum().item()
+        n_audio_features = audio_features_flat.shape[0]
+        if n_audio_tokens != n_audio_features:
+            raise ValueError(
+                f"Audio token count ({n_audio_tokens}) does not match " f"audio feature count ({n_audio_features})."
+            )
+        audio_mask_flat = audio_mask.reshape(-1)
+        inputs_embeds_flat = inputs_embeds.reshape(-1, inputs_embeds.shape[-1])
+        inputs_embeds_flat[audio_mask_flat] = inputs_embeds_flat[audio_mask_flat] + audio_features_flat.to(
+            inputs_embeds.dtype
+        )
+        inputs_embeds = inputs_embeds_flat.reshape(inputs_embeds.shape)
+
+    # ==================================================================
+    # RMPad: unpad + position_ids (mirrors qwen3_vl_ops.model_forward)
+    # ==================================================================
+
+    # 7a. Compute position_ids using qwen3_vl_get_rope_index
+    # The function expects self.config to have image_token_id, video_token_id,
+    # vision_start_token_id, and vision_config.spatial_merge_size.
+    if position_ids is None:
+        position_ids, rope_deltas = qwen3_vl_get_rope_index(
+            self,
+            original_input_ids,
+            image_grid_thw,
+            video_grid_thw,
+            attention_mask=attention_mask,
+        )
+
+    # 7b. Unpad inputs_embeds
+    inputs_embeds, indices, cu_seq_lens, _ = _unpad_input(inputs_embeds, attention_mask=attention_mask)
+
+    # 7c. Unpad position_ids: [3, B, S] -> index by valid positions -> [3, 1, total_tokens]
+    position_ids = (
+        index_first_axis(rearrange(position_ids, "c b s ... -> (b s) c ..."), indices).transpose(0, 1).unsqueeze(1)
+    )
+
+    # Qwen3VLTextModel's Ulysses wrapper pads/slices inputs_embeds before the
+    # text forward. Pad global position_ids to the same padded length so RoPE
+    # cos/sin length matches q/k after all-to-all when total tokens is odd.
+    if sp_size > 1:
+        dummy_ids = torch.zeros(
+            (1, inputs_embeds.shape[0]),
+            dtype=torch.long,
+            device=inputs_embeds.device,
+        )
+        _, position_ids, _ = ulysses_pad(dummy_ids, position_ids, sp_size=sp_size)
+
+    # 7d. Unpad labels
+    if labels is not None:
+        labels_unpad = labels.view(-1)[indices]
+        if sp_size > 1:
+            pad_size = (sp_size - labels_unpad.shape[0] % sp_size) % sp_size
+            if pad_size > 0:
+                labels_unpad = torch.nn.functional.pad(labels_unpad, (0, pad_size), value=-100)
+            labels_unpad = slice_input_tensor(labels_unpad, dim=0, padding=False)
+    else:
+        labels_unpad = None
+
+    # ---- 8. Language model forward ----
+    outputs = self.language_model(
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        indices=indices,
+        cu_seq_lens=cu_seq_lens,
+    )
+
+    hidden_states = outputs.last_hidden_state
+
+    # ---- 9. Loss computation ----
+    loss = None
+    logits = None
+
+    if labels_unpad is not None:
+        # Shift per sequence (rmpad: sequences are packed, can't just shift globally)
+        shift_cu_seq_lens = cu_seq_lens
+        if sp_size > 1:
+            shift_cu_seq_lens = calculate_seq_len_per_rank(cu_seq_lens.tolist())
+
+        shift_hidden_states = []
+        shift_labels = []
+        for i in range(len(shift_cu_seq_lens) - 1):
+            start = shift_cu_seq_lens[i]
+            end = shift_cu_seq_lens[i + 1]
+            cur_hidden = hidden_states[start:end, :]
+            cur_labels = labels_unpad[start:end]
+            shift_hidden_states.append(cur_hidden[:-1, :].contiguous())
+            shift_labels.append(cur_labels[1:].contiguous())
+        shift_hidden_states = torch.cat(shift_hidden_states, dim=0)
+        shift_labels = torch.cat(shift_labels, dim=0)
+
+        # Flatten
+        shift_hidden_states = shift_hidden_states.view(-1, self.config.text_config.hidden_size)
+        shift_labels = shift_labels.view(-1)
+
+        if _HAS_LIGER:
+            reduction = "none" if sp_size > 1 else "mean"
+            lce = LigerFusedLinearCrossEntropyLoss(reduction=reduction)
+            loss = lce(self.lm_head.weight, shift_hidden_states, shift_labels)
+        else:
+            logits = self.lm_head(shift_hidden_states)
+            reduction = "none" if sp_size > 1 else "mean"
+            loss_fct = nn.CrossEntropyLoss(reduction=reduction)
+            loss = loss_fct(logits, shift_labels)
+            logits = None  # Don't return partial logits
+
+        if sp_size > 1:
+            loss, total_padding = pad_to_max_across_ranks(loss, dim=0)
+            loss = gather_outputs_and_unpad(loss, gather_dim=0, unpad_dim=0, padding_size=total_padding)
+            num_valid_tokens = (shift_labels != -100).sum().float()
+            sp_group = get_ulysses_sequence_parallel_group()
+            if sp_group is not None:
+                dist.all_reduce(num_valid_tokens, op=dist.ReduceOp.SUM, group=sp_group)
+            loss = torch.sum(loss) / (num_valid_tokens + 1e-8)
+    else:
+        # Inference: materialize logits
+        logits = self.lm_head(hidden_states)
+
+    if not return_dict:
+        output = (logits,)
+        return (loss,) + output if loss is not None else output
+
+    return AeroRealtimeCausalLMOutputWithPast(
+        loss=loss,
+        logits=logits,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+        audio_hidden_states=audio_features_flat,
+        vision_hidden_states=video_features,
+    )

--- a/src/lmms_engine/models/aero_realtime/backbone_registry.py
+++ b/src/lmms_engine/models/aero_realtime/backbone_registry.py
@@ -1,0 +1,205 @@
+# coding=utf-8
+"""Backbone family registry for AeroRealtime.
+
+Single source of truth mapping ``backbone_family`` ∈
+``{qwen3_vl, qwen3_vl_moe, qwen3_5, qwen3_5_moe}`` to:
+
+- Sub-config classes (text + vision)
+- Sub-model classes (text + vision)
+
+Sub-configs/sub-models are NOT in transformers.AutoConfig / AutoModel
+mappings, so we import the concrete classes directly. The audio tower
+(``qwen2_audio_encoder``) IS registered in AutoConfig/AutoModel and stays
+on the auto path — it lives outside this registry.
+
+Monkey-patch dispatch tables (LIGER_FN / RMPAD_FN) are built lazily by
+``family_liger_fn`` / ``family_rmpad_fn`` to avoid eager-importing
+inner backbone patch modules at module load.
+"""
+
+from transformers.models.qwen3_5.configuration_qwen3_5 import (
+    Qwen3_5TextConfig,
+    Qwen3_5VisionConfig,
+)
+from transformers.models.qwen3_5.modeling_qwen3_5 import (
+    Qwen3_5TextModel,
+    Qwen3_5VisionModel,
+)
+from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import (
+    Qwen3_5MoeTextConfig,
+    Qwen3_5MoeVisionConfig,
+)
+from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
+    Qwen3_5MoeTextModel,
+    Qwen3_5MoeVisionModel,
+)
+from transformers.models.qwen3_vl.configuration_qwen3_vl import (
+    Qwen3VLTextConfig,
+    Qwen3VLVisionConfig,
+)
+from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+    Qwen3VLTextModel,
+    Qwen3VLVisionModel,
+)
+from transformers.models.qwen3_vl_moe.configuration_qwen3_vl_moe import (
+    Qwen3VLMoeTextConfig,
+    Qwen3VLMoeVisionConfig,
+)
+from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import (
+    Qwen3VLMoeTextModel,
+    Qwen3VLMoeVisionModel,
+)
+
+# Family → (text_model_type, vision_model_type, TextConfig, VisionConfig,
+#          TextModel, VisionModel, is_moe)
+BACKBONE_FAMILY = {
+    "qwen3_vl": (
+        "qwen3_vl_text",
+        "qwen3_vl_vision",
+        Qwen3VLTextConfig,
+        Qwen3VLVisionConfig,
+        Qwen3VLTextModel,
+        Qwen3VLVisionModel,
+        False,
+    ),
+    "qwen3_vl_moe": (
+        "qwen3_vl_moe_text",
+        "qwen3_vl_moe_vision",
+        Qwen3VLMoeTextConfig,
+        Qwen3VLMoeVisionConfig,
+        Qwen3VLMoeTextModel,
+        Qwen3VLMoeVisionModel,
+        True,
+    ),
+    "qwen3_5": (
+        "qwen3_5_text",
+        "qwen3_5_vision",
+        Qwen3_5TextConfig,
+        Qwen3_5VisionConfig,
+        Qwen3_5TextModel,
+        Qwen3_5VisionModel,
+        False,
+    ),
+    "qwen3_5_moe": (
+        "qwen3_5_moe_text",
+        "qwen3_5_moe_vision",
+        Qwen3_5MoeTextConfig,
+        Qwen3_5MoeVisionConfig,
+        Qwen3_5MoeTextModel,
+        Qwen3_5MoeVisionModel,
+        True,
+    ),
+}
+
+
+def get_family_entry(family: str):
+    if family not in BACKBONE_FAMILY:
+        raise ValueError(f"unknown backbone_family={family}; " f"expected one of {sorted(BACKBONE_FAMILY)}")
+    return BACKBONE_FAMILY[family]
+
+
+def family_text_model_type(family: str) -> str:
+    return get_family_entry(family)[0]
+
+
+def family_vision_model_type(family: str) -> str:
+    return get_family_entry(family)[1]
+
+
+def family_text_config_cls(family: str):
+    return get_family_entry(family)[2]
+
+
+def family_vision_config_cls(family: str):
+    return get_family_entry(family)[3]
+
+
+def family_text_model_cls(family: str):
+    return get_family_entry(family)[4]
+
+
+def family_vision_model_cls(family: str):
+    return get_family_entry(family)[5]
+
+
+def family_is_moe(family: str) -> bool:
+    return get_family_entry(family)[6]
+
+
+# ---------------------------------------------------------------------------
+# Monkey-patch dispatch tables.
+# Each callable takes ``model=<aero.language_model>`` (+ **liger_flags for
+# the liger variant) and applies the family's patches.
+#
+# For qwen3_5_moe we use the OV2-split entries directly. For the other
+# three families (still combined-style), we adapt via lambda with
+# use_rmpad=True/False and per-flag toggles.
+#
+# Tables are built lazily inside ``_build_family_patch_dispatch`` because
+# importing the inner backbone monkey_patch modules at module load would
+# eagerly import their model classes and slow down config-only consumers.
+# ---------------------------------------------------------------------------
+
+
+def _build_family_patch_dispatch():
+    from lmms_engine.models.qwen3_5.monkey_patch import apply_liger_kernel_to_qwen3_5
+    from lmms_engine.models.qwen3_5_moe.monkey_patch import (
+        apply_liger_kernel_to_qwen3_5_moe,
+        apply_rmpad_to_qwen3_5_moe,
+    )
+    from lmms_engine.models.qwen3_vl.monkey_patch import apply_liger_kernel_to_qwen3_vl
+    from lmms_engine.models.qwen3_vl_moe.monkey_patch import (
+        apply_liger_kernel_to_qwen3_vl_moe,
+    )
+
+    LIGER_FN = {
+        "qwen3_vl": lambda model=None, **kw: apply_liger_kernel_to_qwen3_vl(model=model, use_rmpad=False, **kw),
+        "qwen3_vl_moe": lambda model=None, **kw: apply_liger_kernel_to_qwen3_vl_moe(model=model, use_rmpad=False, **kw),
+        "qwen3_5": lambda model=None, **kw: apply_liger_kernel_to_qwen3_5(model=model, use_rmpad=False, **kw),
+        "qwen3_5_moe": apply_liger_kernel_to_qwen3_5_moe,
+    }
+    RMPAD_FN = {
+        "qwen3_vl": lambda model=None: apply_liger_kernel_to_qwen3_vl(
+            model=model,
+            use_rmpad=True,
+            rope=False,
+            rms_norm=False,
+            swiglu=False,
+            cross_entropy=False,
+            fused_linear_cross_entropy=False,
+        ),
+        "qwen3_vl_moe": lambda model=None: apply_liger_kernel_to_qwen3_vl_moe(
+            model=model,
+            use_rmpad=True,
+            rope=False,
+            rms_norm=False,
+            swiglu=False,
+            cross_entropy=False,
+            fused_linear_cross_entropy=False,
+        ),
+        "qwen3_5": lambda model=None: apply_liger_kernel_to_qwen3_5(
+            model=model,
+            use_rmpad=True,
+            rope=False,
+            rms_norm=False,
+            swiglu=False,
+            cross_entropy=False,
+            fused_linear_cross_entropy=False,
+        ),
+        "qwen3_5_moe": apply_rmpad_to_qwen3_5_moe,
+    }
+    return LIGER_FN, RMPAD_FN
+
+
+def family_liger_fn(family: str):
+    LIGER_FN, _ = _build_family_patch_dispatch()
+    if family not in LIGER_FN:
+        raise ValueError(f"no liger entry for backbone_family={family}")
+    return LIGER_FN[family]
+
+
+def family_rmpad_fn(family: str):
+    _, RMPAD_FN = _build_family_patch_dispatch()
+    if family not in RMPAD_FN:
+        raise ValueError(f"no rmpad entry for backbone_family={family}")
+    return RMPAD_FN[family]

--- a/src/lmms_engine/models/aero_realtime/backbone_registry.py
+++ b/src/lmms_engine/models/aero_realtime/backbone_registry.py
@@ -203,3 +203,30 @@ def family_rmpad_fn(family: str):
     if family not in RMPAD_FN:
         raise ValueError(f"no rmpad entry for backbone_family={family}")
     return RMPAD_FN[family]
+
+
+# ---------------------------------------------------------------------------
+# ViT frame-parallel dispatch (optional per family).
+#
+# Only ``qwen3_5`` exposes a frame-parallel ViT wrap today; the other three
+# families fall back to no-op. The wrap is a *class-level* monkey-patch
+# on the family's VisionModel class, so it works for aero out of the box
+# once the right family fn is called.
+# ---------------------------------------------------------------------------
+
+
+def _build_family_vit_frame_parallel_dispatch():
+    from lmms_engine.models.qwen3_5.monkey_patch import (
+        apply_vit_frame_parallel_to_qwen3_5,
+    )
+
+    return {
+        "qwen3_5": apply_vit_frame_parallel_to_qwen3_5,
+    }
+
+
+def family_vit_frame_parallel_fn(family: str):
+    """Return the family's frame-parallel ViT wrap fn, or ``None`` if the
+    family doesn't support frame-parallel ViT."""
+    table = _build_family_vit_frame_parallel_dispatch()
+    return table.get(family)

--- a/src/lmms_engine/models/aero_realtime/backbone_registry.py
+++ b/src/lmms_engine/models/aero_realtime/backbone_registry.py
@@ -208,8 +208,8 @@ def family_rmpad_fn(family: str):
 # ---------------------------------------------------------------------------
 # ViT frame-parallel dispatch (optional per family).
 #
-# ``qwen3_vl`` and ``qwen3_5`` expose frame-parallel ViT wraps today; the
-# other two families fall back to no-op. The wrap is a *class-level* monkey-patch
+# ``qwen3_vl``, ``qwen3_vl_moe`` and ``qwen3_5`` expose frame-parallel ViT wraps
+# today; ``qwen3_5_moe`` falls back to no-op. The wrap is a *class-level* monkey-patch
 # on the family's VisionModel class, so it works for aero out of the box
 # once the right family fn is called.
 # ---------------------------------------------------------------------------
@@ -222,9 +222,13 @@ def _build_family_vit_frame_parallel_dispatch():
     from lmms_engine.models.qwen3_vl.monkey_patch import (
         apply_vit_frame_parallel_to_qwen3_vl,
     )
+    from lmms_engine.models.qwen3_vl_moe.monkey_patch import (
+        apply_vit_frame_parallel_to_qwen3_vl_moe,
+    )
 
     return {
         "qwen3_vl": apply_vit_frame_parallel_to_qwen3_vl,
+        "qwen3_vl_moe": apply_vit_frame_parallel_to_qwen3_vl_moe,
         "qwen3_5": apply_vit_frame_parallel_to_qwen3_5,
     }
 

--- a/src/lmms_engine/models/aero_realtime/backbone_registry.py
+++ b/src/lmms_engine/models/aero_realtime/backbone_registry.py
@@ -208,8 +208,8 @@ def family_rmpad_fn(family: str):
 # ---------------------------------------------------------------------------
 # ViT frame-parallel dispatch (optional per family).
 #
-# Only ``qwen3_5`` exposes a frame-parallel ViT wrap today; the other three
-# families fall back to no-op. The wrap is a *class-level* monkey-patch
+# ``qwen3_vl`` and ``qwen3_5`` expose frame-parallel ViT wraps today; the
+# other two families fall back to no-op. The wrap is a *class-level* monkey-patch
 # on the family's VisionModel class, so it works for aero out of the box
 # once the right family fn is called.
 # ---------------------------------------------------------------------------
@@ -219,8 +219,12 @@ def _build_family_vit_frame_parallel_dispatch():
     from lmms_engine.models.qwen3_5.monkey_patch import (
         apply_vit_frame_parallel_to_qwen3_5,
     )
+    from lmms_engine.models.qwen3_vl.monkey_patch import (
+        apply_vit_frame_parallel_to_qwen3_vl,
+    )
 
     return {
+        "qwen3_vl": apply_vit_frame_parallel_to_qwen3_vl,
         "qwen3_5": apply_vit_frame_parallel_to_qwen3_5,
     }
 

--- a/src/lmms_engine/models/aero_realtime/configuration_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/configuration_aero_realtime.py
@@ -75,6 +75,8 @@ class AeroRealtimeAudioEncoderConfig(PretrainedConfig):
         attention_window_right: int = 0,
         norm_type: str = "rms_norm",
         mlp_type: str = "swiglu",
+        conv_padding: str = "causal",
+        k_proj_bias: bool = False,
         rope_parameters: dict | None = None,
         **kwargs,
     ):
@@ -103,8 +105,12 @@ class AeroRealtimeAudioEncoderConfig(PretrainedConfig):
             raise ValueError(f"norm_type must be 'rms_norm' or 'layer_norm', got {norm_type}")
         if mlp_type not in ("swiglu", "gelu"):
             raise ValueError(f"mlp_type must be 'swiglu' or 'gelu', got {mlp_type}")
+        if conv_padding not in ("causal", "symmetric"):
+            raise ValueError(f"conv_padding must be 'causal' or 'symmetric', got {conv_padding}")
         self.norm_type = norm_type
         self.mlp_type = mlp_type
+        self.conv_padding = conv_padding
+        self.k_proj_bias = bool(k_proj_bias)
 
         self.rope_parameters = rope_parameters or {"rope_type": "default", "rope_theta": 1000000.0}
 

--- a/src/lmms_engine/models/aero_realtime/configuration_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/configuration_aero_realtime.py
@@ -1,0 +1,231 @@
+# coding=utf-8
+# Copyright 2025 LMMs-Lab team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AeroRealtime model configuration.
+
+A multimodal model combining audio, vision, and language capabilities.
+Inspired by VoxtralRealtime but extended with vision support for
+image and video inputs.
+"""
+
+from transformers.configuration_utils import PretrainedConfig
+from transformers.models.auto import CONFIG_MAPPING, AutoConfig
+
+from .backbone_registry import (
+    BACKBONE_FAMILY,
+    family_text_config_cls,
+    family_text_model_type,
+    family_vision_config_cls,
+    family_vision_model_type,
+)
+
+
+class AeroRealtimeConfig(PretrainedConfig):
+    r"""
+    Configuration class for AeroRealtime model.
+
+    AeroRealtime is a multimodal model that combines an audio encoder,
+    a vision encoder, and a language model with an audio projector.
+
+    Args:
+        text_config (`dict` or `PretrainedConfig`, *optional*):
+            Configuration for the language model backbone. When passed as a dict,
+            it is resolved via `CONFIG_MAPPING` using the `model_type` key.
+            Defaults to a Qwen3-style config if not provided.
+        audio_config (`dict` or `PretrainedConfig`, *optional*):
+            Configuration for the audio encoder tower. When passed as a dict,
+            it is resolved via `CONFIG_MAPPING` using the `model_type` key.
+            Defaults to a Qwen2 audio encoder config if not provided.
+        vision_config (`dict` or `PretrainedConfig`, *optional*):
+            Configuration for the vision encoder tower. When passed as a dict,
+            it is resolved via `CONFIG_MAPPING` using the `model_type` key.
+            Defaults to a Qwen3 VL vision config if not provided.
+        projector_hidden_act (`str`, *optional*, defaults to `"gelu"`):
+            Activation function used in the audio multi-modal projector.
+        audio_length_per_tok (`int`, *optional*, defaults to `8`):
+            Number of audio feature frames per text token.
+        downsample_factor (`int`, *optional*, defaults to `4`):
+            Factor by which audio features are downsampled (concatenated) before
+            projection. The audio projector input dimension is
+            `audio_config.hidden_size * downsample_factor`.
+        audio_token_index (`int`, *optional*, defaults to `151671`):
+            Token index for ``<|audio_pad|>`` — placeholder for audio features
+            in the input sequence.
+        audio_start_token_index (`int`, *optional*, defaults to `151669`):
+            Token index for ``<|audio_start|>`` — opens an audio segment.
+            Also exposed as ``audio_start_token_id``.
+        audio_end_token_index (`int`, *optional*, defaults to `151670`):
+            Token index for ``<|audio_end|>`` — closes an audio segment.
+            Also exposed as ``audio_end_token_id``.
+        image_token_index (`int`, *optional*, defaults to `151655`):
+            Token index used as a placeholder for image features in the input sequence.
+            Also exposed as ``image_token_id`` for compatibility with shared RoPE helpers.
+        video_token_index (`int`, *optional*, defaults to `151656`):
+            Token index used as a placeholder for video features in the input sequence.
+            Also exposed as ``video_token_id`` for compatibility with shared RoPE helpers.
+        vision_start_token_index (`int`, *optional*, defaults to `151652`):
+            Token index for ``<|vision_start|>``. Used by the shared mrope
+            position index computation (``qwen3_vl_get_rope_index``).
+            Also exposed as ``vision_start_token_id``.
+        rt_start_token_index (`int`, *optional*, defaults to `151672`):
+            Token index for ``<|rt_start|>`` — the first token of the realtime text stream.
+        rt_pad_token_index (`int`, *optional*, defaults to `151673`):
+            Token index for ``<|rt_pad|>`` — silence token in the realtime text stream.
+        rt_speak_token_index (`int`, *optional*, defaults to `151674`):
+            Token index for ``<|rt_speak|>`` — delay boundary marker after which
+            the model may begin producing text.
+        rt_end_token_index (`int`, *optional*, defaults to `151675`):
+            Token index for ``<|rt_end|>`` — closes one realtime speech span.
+        tie_word_embeddings (`bool`, *optional*, defaults to `False`):
+            Whether to tie the language model's input and output word embeddings.
+
+    Example:
+        ```python
+        from lmms_engine.models.aero_realtime import AeroRealtimeConfig
+
+        config = AeroRealtimeConfig(
+            text_config={"model_type": "qwen3", "hidden_size": 3584},
+            audio_config={"model_type": "qwen2_audio_encoder"},
+            vision_config={"hidden_size": 1152, "out_hidden_size": 3584},
+        )
+        ```
+    """
+
+    model_type = "aero_realtime"
+
+    sub_configs = {
+        "text_config": AutoConfig,
+        "audio_config": AutoConfig,
+        "vision_config": AutoConfig,
+    }
+
+    def __init__(
+        self,
+        backbone_family: str = "qwen3_vl",
+        text_config=None,
+        audio_config=None,
+        vision_config=None,
+        projector_hidden_act="gelu",
+        audio_length_per_tok=8,
+        downsample_factor=4,
+        audio_token_index=151671,
+        audio_start_token_index=151669,
+        audio_end_token_index=151670,
+        image_token_index=151655,
+        video_token_index=151656,
+        vision_start_token_index=151652,
+        rt_start_token_index=151672,
+        rt_pad_token_index=151673,
+        rt_speak_token_index=151674,
+        rt_end_token_index=151675,
+        tie_word_embeddings=False,
+        **kwargs,
+    ):
+        # --- Resolve backbone_family ---
+        # Defaults to "qwen3_vl" so legacy ckpts (saved before this field
+        # existed) and HF's no-arg ``AeroRealtimeConfig()`` (called by
+        # ``to_diff_dict``) keep working.
+        if backbone_family not in BACKBONE_FAMILY:
+            raise ValueError(
+                f"unknown backbone_family={backbone_family}; " f"expected one of {sorted(BACKBONE_FAMILY)}"
+            )
+        self.backbone_family = backbone_family
+        text_mt = family_text_model_type(backbone_family)
+        vision_mt = family_vision_model_type(backbone_family)
+
+        # --- Plain field assignments (unchanged from previous version) ---
+        self.projector_hidden_act = projector_hidden_act
+        self.audio_length_per_tok = audio_length_per_tok
+        self.downsample_factor = downsample_factor
+        self.audio_token_index = audio_token_index
+        self.audio_start_token_index = audio_start_token_index
+        self.audio_end_token_index = audio_end_token_index
+        self.image_token_index = image_token_index
+        self.video_token_index = video_token_index
+        self.vision_start_token_index = vision_start_token_index
+        self.rt_start_token_index = rt_start_token_index
+        self.rt_pad_token_index = rt_pad_token_index
+        self.rt_speak_token_index = rt_speak_token_index
+        self.rt_end_token_index = rt_end_token_index
+        # Aliases for shared rope helper
+        self.image_token_id = image_token_index
+        self.video_token_id = video_token_index
+        self.vision_start_token_id = vision_start_token_index
+        self.audio_token_id = audio_token_index
+        self.audio_start_token_id = audio_start_token_index
+        self.audio_end_token_id = audio_end_token_index
+
+        # --- Resolve text_config (registry-driven) ---
+        # Legacy ckpts may have written text_config.model_type=<family> instead
+        # of "<family>_text" — accept both for back-compat.
+        text_cfg_cls = family_text_config_cls(backbone_family)
+        if isinstance(text_config, dict):
+            mt = text_config.get("model_type", text_mt)
+            if mt not in (text_mt, backbone_family):
+                raise ValueError(
+                    f"text_config.model_type={mt} does not match family " f"{backbone_family} (expected {text_mt})"
+                )
+            text_config = dict(text_config)
+            text_config.pop("model_type", None)
+            text_config = text_cfg_cls(**text_config)
+        elif text_config is None:
+            text_config = text_cfg_cls()
+        self.text_config = text_config
+
+        # --- Resolve audio_config (unchanged — AutoConfig works for it) ---
+        if isinstance(audio_config, dict):
+            audio_config["model_type"] = audio_config.get("model_type", "qwen2_audio_encoder")
+            audio_config = CONFIG_MAPPING[audio_config["model_type"]](**audio_config)
+        elif audio_config is None:
+            audio_config = CONFIG_MAPPING["qwen2_audio_encoder"](
+                d_model=1280,
+                encoder_attention_heads=20,
+                encoder_ffn_dim=5120,
+                encoder_layerdrop=0.0,
+                encoder_layers=32,
+                num_mel_bins=128,
+                max_source_positions=1500,
+                scale_embedding=False,
+                activation_function="gelu",
+            )
+        self.audio_config = audio_config
+
+        # --- Resolve vision_config (registry-driven) ---
+        # Legacy ckpts wrote vision_config.model_type=<family> (e.g. "qwen3_vl")
+        # instead of the proper "<family>_vision" — accept both for back-compat.
+        vision_cfg_cls = family_vision_config_cls(backbone_family)
+        if isinstance(vision_config, dict):
+            mt = vision_config.get("model_type", vision_mt)
+            if mt not in (vision_mt, backbone_family):
+                raise ValueError(
+                    f"vision_config.model_type={mt} does not match family " f"{backbone_family} (expected {vision_mt})"
+                )
+            vision_config = dict(vision_config)
+            vision_config.pop("model_type", None)
+            vision_config = vision_cfg_cls(**vision_config)
+        elif vision_config is None:
+            vision_config = vision_cfg_cls()
+        self.vision_config = vision_config
+
+        # Expose text hidden size at top level for convenience
+        self.hidden_size = self.text_config.hidden_size
+        self.audio_hidden_size = getattr(self.audio_config, "hidden_size", None) or getattr(
+            self.audio_config, "d_model", None
+        )
+
+        if tie_word_embeddings is False and getattr(self.text_config, "tie_word_embeddings", False):
+            tie_word_embeddings = True
+
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)

--- a/src/lmms_engine/models/aero_realtime/configuration_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/configuration_aero_realtime.py
@@ -73,6 +73,7 @@ class AeroRealtimeAudioEncoderConfig(PretrainedConfig):
         sliding_window: int | None = 750,
         attention_window_left: int | None = None,
         attention_window_right: int = 0,
+        is_causal: bool = False,
         norm_type: str = "rms_norm",
         mlp_type: str = "swiglu",
         conv_padding: str = "causal",
@@ -100,6 +101,7 @@ class AeroRealtimeAudioEncoderConfig(PretrainedConfig):
             attention_window_left = (sliding_window - 1) if sliding_window is not None else -1
         self.attention_window_left = attention_window_left
         self.attention_window_right = attention_window_right
+        self.is_causal = bool(is_causal)
 
         if norm_type not in ("rms_norm", "layer_norm"):
             raise ValueError(f"norm_type must be 'rms_norm' or 'layer_norm', got {norm_type}")

--- a/src/lmms_engine/models/aero_realtime/configuration_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/configuration_aero_realtime.py
@@ -184,22 +184,15 @@ class AeroRealtimeConfig(PretrainedConfig):
             text_config = text_cfg_cls()
         self.text_config = text_config
 
-        # --- Resolve audio_config (unchanged — AutoConfig works for it) ---
+        # --- Resolve audio_config ---
+        # Defaults to voxtral_realtime_encoder. When audio_config is None we
+        # let the Voxtral encoder config supply its own defaults — do not
+        # duplicate kwargs here (keeps us in sync with upstream).
         if isinstance(audio_config, dict):
-            audio_config["model_type"] = audio_config.get("model_type", "qwen2_audio_encoder")
+            audio_config["model_type"] = audio_config.get("model_type", "voxtral_realtime_encoder")
             audio_config = CONFIG_MAPPING[audio_config["model_type"]](**audio_config)
         elif audio_config is None:
-            audio_config = CONFIG_MAPPING["qwen2_audio_encoder"](
-                d_model=1280,
-                encoder_attention_heads=20,
-                encoder_ffn_dim=5120,
-                encoder_layerdrop=0.0,
-                encoder_layers=32,
-                num_mel_bins=128,
-                max_source_positions=1500,
-                scale_embedding=False,
-                activation_function="gelu",
-            )
+            audio_config = CONFIG_MAPPING["voxtral_realtime_encoder"]()
         self.audio_config = audio_config
 
         # --- Resolve vision_config (registry-driven) ---

--- a/src/lmms_engine/models/aero_realtime/configuration_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/configuration_aero_realtime.py
@@ -32,6 +32,85 @@ from .backbone_registry import (
 )
 
 
+class AeroRealtimeAudioEncoderConfig(PretrainedConfig):
+    """Config for the Aero-owned realtime audio encoder.
+
+    Defaults mirror HuggingFace ``VoxtralRealtimeEncoderConfig`` so existing
+    Voxtral Realtime audio tower weights load without conversion. Adds:
+
+    - ``norm_type``: ``"rms_norm"`` (default, Voxtral-compat) or ``"layer_norm"``
+    - ``mlp_type``: ``"swiglu"`` (default, Voxtral-compat) or ``"gelu"``
+    - ``attention_window_left`` / ``attention_window_right``: explicit window
+      bounds; default is one-way local (right=0, left=sliding_window-1).
+    """
+
+    model_type = "aero_realtime_audio_encoder"
+
+    attribute_map = {
+        "d_model": "hidden_size",
+        "encoder_layers": "num_hidden_layers",
+        "encoder_attention_heads": "num_attention_heads",
+        "encoder_ffn_dim": "intermediate_size",
+        "encoder_layerdrop": "layerdrop",
+    }
+
+    def __init__(
+        self,
+        vocab_size: int = 131072,
+        hidden_size: int = 1280,
+        intermediate_size: int = 5120,
+        num_hidden_layers: int = 32,
+        num_attention_heads: int = 32,
+        num_key_value_heads: int | None = None,
+        head_dim: int = 64,
+        num_mel_bins: int = 128,
+        max_position_embeddings: int = 1500,
+        activation_function: str = "gelu",
+        hidden_act: str = "silu",
+        rms_norm_eps: float = 1e-5,
+        attention_dropout: float = 0.0,
+        initializer_range: float = 0.02,
+        sliding_window: int | None = 750,
+        attention_window_left: int | None = None,
+        attention_window_right: int = 0,
+        norm_type: str = "rms_norm",
+        mlp_type: str = "swiglu",
+        rope_parameters: dict | None = None,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads if num_key_value_heads is not None else num_attention_heads
+        self.head_dim = head_dim if head_dim is not None else hidden_size // num_attention_heads
+        self.num_mel_bins = num_mel_bins
+        self.max_position_embeddings = max_position_embeddings
+        self.activation_function = activation_function
+        self.hidden_act = hidden_act
+        self.rms_norm_eps = rms_norm_eps
+        self.attention_dropout = attention_dropout
+        self.initializer_range = initializer_range
+        self.sliding_window = sliding_window
+
+        if attention_window_left is None:
+            attention_window_left = (sliding_window - 1) if sliding_window is not None else -1
+        self.attention_window_left = attention_window_left
+        self.attention_window_right = attention_window_right
+
+        if norm_type not in ("rms_norm", "layer_norm"):
+            raise ValueError(f"norm_type must be 'rms_norm' or 'layer_norm', got {norm_type}")
+        if mlp_type not in ("swiglu", "gelu"):
+            raise ValueError(f"mlp_type must be 'swiglu' or 'gelu', got {mlp_type}")
+        self.norm_type = norm_type
+        self.mlp_type = mlp_type
+
+        self.rope_parameters = rope_parameters or {"rope_type": "default", "rope_theta": 1000000.0}
+
+        super().__init__(**kwargs)
+
+
 class AeroRealtimeConfig(PretrainedConfig):
     r"""
     Configuration class for AeroRealtime model.

--- a/src/lmms_engine/models/aero_realtime/modeling_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/modeling_aero_realtime.py
@@ -192,9 +192,6 @@ class AeroRealtimeForConditionalGeneration(AeroRealtimePreTrainedModel, Generati
         self.lm_head = nn.Linear(config.text_config.hidden_size, config.text_config.vocab_size, bias=False)
         self.multi_modal_projector = AeroRealtimeMultiModalProjector(config)
 
-        # Cache audio tower type for dispatch
-        self.audio_tower_type = config.audio_config.model_type
-
         self.post_init()
 
         # Cached rope deltas for incremental position_ids during generation
@@ -359,59 +356,47 @@ class AeroRealtimeForConditionalGeneration(AeroRealtimePreTrainedModel, Generati
         self,
         input_features: torch.FloatTensor,
         audio_attention_mask: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Extract audio features via the audio tower, downsample, and project.
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Extract audio features via the Voxtral encoder, then reshape and project.
 
-        Following VoxtralRealtime's approach:
-        1. Run audio through the audio encoder tower.
-        2. Reshape by concatenating ``downsample_factor`` consecutive frames.
-        3. Project through the 2-layer MLP (``multi_modal_projector``).
+        Voxtral's audio encoder is run on a padded batch with the post-conv2
+        attention mask passed through. Transformers' FA2 integration auto-
+        unpads on a 2D mask (see ``modeling_flash_attention_utils._upad_input``),
+        so padding-region tokens cost nothing in attention/MLP under
+        ``flash_attention_2``. The mask is ALSO used downstream to derive
+        per-sample valid LM-token lengths via ``audio_output_lengths``.
 
         Args:
-            input_features: Mel spectrogram features.
-                Shape ``[batch_size, num_mel_bins, mel_seq_len]`` or as
-                expected by the audio tower.
-            audio_attention_mask: Attention mask at mel-frame level.
-                Shape ``[batch_size, mel_seq_len]``.
+            input_features: Mel spectrogram features, shape ``(B, n_mels=128, T_mel)``.
+            audio_attention_mask: **Post-conv2** attention mask, shape
+                ``(B, T_enc)`` where ``T_enc = T_mel // 2``. The
+                processor is responsible for emitting this at the correct
+                length (Voxtral's conv2 with stride=2 reduces mel_len // 2;
+                a mel-level mask will trigger a runtime size mismatch).
+                ``1 = valid``, ``0 = padding``.
 
         Returns:
             Tuple of:
-            - Projected audio features of shape
-              ``[batch_size, num_audio_tokens, hidden_dim]``
-              where ``num_audio_tokens = encoder_seq_len / downsample_factor``
-              and ``hidden_dim = text_config.hidden_size``.
-            - ``audio_output_lengths`` of shape ``[batch_size]``, the number
-              of valid (unpadded) encoder output tokens per sample.
+              - audio_features: shape ``(B, T_enc // downsample_factor, text_hidden)``
+              - audio_output_lengths: shape ``(B,)``; number of valid LM
+                audio tokens per sample, or ``None`` if no mask was given.
         """
-        # Compute audio feature/output lengths via encoder's own method
-        audio_output_lengths = None
-        encoder_kwargs = {}
-
-        if audio_attention_mask is not None and hasattr(self.audio_tower, "_get_feat_extract_output_lengths"):
-            mel_lengths = audio_attention_mask.sum(-1)
-            audio_feat_lengths, audio_output_lengths = self.audio_tower._get_feat_extract_output_lengths(mel_lengths)
-
-            # Qwen2Audio encoder needs a custom 4D attention mask
-            if self.audio_tower_type == "qwen2_audio_encoder":
-                encoder_kwargs["attention_mask"] = self._build_qwen2_audio_attention_mask(
-                    input_features, audio_feat_lengths
-                )
-
-        audio_outputs = self.audio_tower(input_features=input_features, **encoder_kwargs)
-
+        audio_outputs = self.audio_tower(
+            input_features=input_features,
+            attention_mask=audio_attention_mask,
+        )
         if isinstance(audio_outputs, torch.Tensor):
             audio_hidden_states = audio_outputs
         else:
             audio_hidden_states = audio_outputs.last_hidden_state
 
-        # Downsample: concatenate `downsample_factor` consecutive frames
-        # [B, seq_len, audio_hidden] -> [B, seq_len/df, audio_hidden * df]
-        # Truncate seq_len to nearest multiple of downsample_factor
+        # Reshape: concat downsample_factor consecutive encoder frames into one
+        # LM-bound audio frame. Truncate to a multiple of downsample_factor
+        # along seq dim. (B, T_enc, hidden) -> (B, T_enc // df, hidden * df)
         df = self.config.downsample_factor
         seq_len = audio_hidden_states.shape[1]
         usable_len = (seq_len // df) * df
         audio_hidden_states = audio_hidden_states[:, :usable_len, :]
-
         audio_hidden_states = audio_hidden_states.reshape(
             audio_hidden_states.shape[0],
             -1,
@@ -421,54 +406,12 @@ class AeroRealtimeForConditionalGeneration(AeroRealtimePreTrainedModel, Generati
         # Project to text hidden dim
         audio_features = self.multi_modal_projector(audio_hidden_states)
 
-        # Adjust output lengths for downsample factor
-        if audio_output_lengths is not None:
-            audio_output_lengths = audio_output_lengths // self.config.downsample_factor
+        # Derive LM-token-level valid lengths from the post-conv2 mask
+        audio_output_lengths = None
+        if audio_attention_mask is not None:
+            audio_output_lengths = audio_attention_mask.sum(-1) // df
 
         return audio_features, audio_output_lengths
-
-    def _build_qwen2_audio_attention_mask(
-        self,
-        input_features: torch.Tensor,
-        audio_feat_lengths: torch.Tensor,
-    ) -> torch.Tensor:
-        """Build the 4D attention mask expected by the Qwen2Audio encoder.
-
-        The encoder applies two downsampling stages (conv2 stride=2, avg_pool
-        stride=2), so the mask is built at the post-conv2 sequence length.
-
-        Args:
-            input_features: ``[batch_size, num_mel_bins, mel_seq_len]``
-            audio_feat_lengths: ``[batch_size]`` -- number of valid tokens
-                after the first conv2 downsampling.
-
-        Returns:
-            4D float attention mask of shape
-            ``[batch_size, 1, max_seq_len, max_seq_len]`` with ``-inf``
-            at padding positions.
-        """
-        batch_size = input_features.shape[0]
-        max_mel_seq_len = input_features.shape[-1]
-        max_seq_len = (max_mel_seq_len - 2) // 2 + 1
-
-        seq_range = (
-            torch.arange(0, max_seq_len, dtype=audio_feat_lengths.dtype, device=audio_feat_lengths.device)
-            .unsqueeze(0)
-            .expand(batch_size, max_seq_len)
-        )
-        lengths_expand = audio_feat_lengths.unsqueeze(1).expand(batch_size, max_seq_len)
-        padding_mask = seq_range >= lengths_expand
-
-        attention_mask = padding_mask.view(batch_size, 1, 1, max_seq_len).expand(
-            batch_size, 1, max_seq_len, max_seq_len
-        )
-        attention_mask = attention_mask.to(
-            dtype=self.audio_tower.conv1.weight.dtype,
-            device=self.audio_tower.conv1.weight.device,
-        )
-        attention_mask = attention_mask.clone()
-        attention_mask[padding_mask.view(batch_size, 1, 1, max_seq_len).expand_as(attention_mask)] = float("-inf")
-        return attention_mask
 
     @staticmethod
     def _unpad_audio_features(

--- a/src/lmms_engine/models/aero_realtime/modeling_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/modeling_aero_realtime.py
@@ -20,23 +20,48 @@ Inspired by VoxtralRealtime but extended with vision support for
 image and video inputs.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
+from functools import cached_property
 from typing import List, Optional, Tuple, Union
 
 import torch
 import torch.utils.checkpoint
 from torch import nn
 from transformers.activations import ACT2FN
+from transformers.cache_utils import Cache, DynamicCache
 from transformers.generation import GenerationMixin
 from transformers.initialization import normal_, zeros_
-from transformers.modeling_outputs import ModelOutput
-from transformers.modeling_utils import PreTrainedModel
+from transformers.integrations import (
+    use_kernel_forward_from_hub,
+    use_kernel_func_from_hub,
+    use_kernelized_func,
+)
+from transformers.masking_utils import (
+    create_causal_mask,
+    create_sliding_window_causal_mask,
+)
+from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    BaseModelOutputWithPooling,
+    ModelOutput,
+)
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from transformers.models.auto import AutoModel, AutoModelForCausalLM
-from transformers.utils import logging
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs, is_torchdynamo_compiling, logging
+from transformers.utils.generic import maybe_autocast, merge_with_config_defaults
+from transformers.utils.output_capturing import capture_outputs
 
 from ..common_ops.rope import qwen3_vl_get_rope_index
 from .backbone_registry import family_text_model_cls, family_vision_model_cls
-from .configuration_aero_realtime import AeroRealtimeConfig
+from .configuration_aero_realtime import (
+    AeroRealtimeAudioEncoderConfig,
+    AeroRealtimeConfig,
+)
 
 logger = logging.get_logger(__name__)
 
@@ -647,4 +672,688 @@ class AeroRealtimeForConditionalGeneration(AeroRealtimePreTrainedModel, Generati
             attentions=outputs.attentions,
             audio_hidden_states=audio_features_flat,
             vision_hidden_states=video_features,
+        )
+
+
+class AeroRealtimeAudioConv1dCacheLayer:
+    def __init__(self):
+        self.cache: torch.Tensor | None = None
+        self.is_initialized: bool = False
+
+    def lazy_initialization(self, hidden_states, conv_module):
+        self.left_pad = conv_module.left_pad
+        self.in_channels = conv_module.in_channels
+        self.cache = torch.zeros(
+            hidden_states.shape[0],
+            self.in_channels,
+            self.left_pad,
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+
+        if not is_torchdynamo_compiling():
+            torch._dynamo.mark_static_address(self.cache)
+
+        self.is_initialized = True
+
+    def update(self, hidden_states, conv_module=None):
+        if not self.is_initialized and conv_module is not None:
+            self.lazy_initialization(hidden_states, conv_module)
+        elif not self.is_initialized:
+            raise ValueError(
+                "AeroRealtimeAudioConv1dCacheLayer is not initialized. Make sure to provide conv_module to the update method."
+            )
+
+        # get the padding states
+        if self.left_pad > 0:
+            shortfall = max(0, self.left_pad - hidden_states.shape[-1])
+            if shortfall > 0:
+                padding_states = torch.cat([self.cache[:, :, -shortfall:], hidden_states], dim=-1)
+            else:
+                padding_states = hidden_states[:, :, -self.left_pad :]
+        else:
+            padding_states = torch.empty(
+                hidden_states.shape[0], self.in_channels, 0, dtype=hidden_states.dtype, device=hidden_states.device
+            )
+
+        current_cache = self.cache.clone()
+        self.cache.copy_(padding_states)
+
+        return current_cache
+
+
+class AeroRealtimeAudioConv1dPaddingCache:
+    def __init__(self):
+        self.layers = {}
+
+    def update(self, hidden_states, cache_key, conv_module):
+        if cache_key not in self.layers:
+            self.layers[cache_key] = AeroRealtimeAudioConv1dCacheLayer()
+
+        padding_states = self.layers[cache_key].update(hidden_states, conv_module)
+        padded_hidden_states = torch.cat([padding_states, hidden_states], dim=-1)
+        return padded_hidden_states
+
+
+@dataclass
+class AeroRealtimeAudioEncoderOutput(BaseModelOutputWithPast):
+    padding_cache: AeroRealtimeAudioConv1dPaddingCache | None = None
+
+
+class AeroRealtimeAudioRotaryEmbedding(nn.Module):
+    inv_freq: torch.Tensor  # fix linting for `register_buffer`
+
+    def __init__(self, config: AeroRealtimeAudioEncoderConfig, device=None):
+        super().__init__()
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+
+        self.rope_type = self.config.rope_parameters["rope_type"]
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(self.config, device)
+
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
+
+    @staticmethod
+    def compute_default_rope_parameters(
+        config: AeroRealtimeAudioEncoderConfig | None = None,
+        device: Optional["torch.device"] = None,
+        seq_len: int | None = None,
+    ) -> tuple["torch.Tensor", float]:
+        """
+        Computes the inverse frequencies according to the original RoPE implementation
+        Args:
+            config ([`~transformers.PreTrainedConfig`]):
+                The model configuration.
+            device (`torch.device`):
+                The device to use for initialization of the inverse frequencies.
+            seq_len (`int`, *optional*):
+                The current sequence length. Unused for this type of RoPE.
+        Returns:
+            Tuple of (`torch.Tensor`, `float`), containing the inverse frequencies for the RoPE embeddings and the
+            post-processing scaling factor applied to the computed cos/sin (unused in this type of RoPE).
+        """
+        base = config.rope_parameters["rope_theta"]
+        dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+
+        attention_factor = 1.0  # Unused in this type of RoPE
+
+        # Compute the inverse frequencies
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+        )
+        return inv_freq, attention_factor
+
+    @torch.no_grad()
+    @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
+    def forward(self, x, position_ids):
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with maybe_autocast(device_type=device_type, enabled=False):  # Force float32
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+class AeroRealtimeAudioCausalConv1d(nn.Conv1d):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        cache_key: str,
+        stride: int = 1,
+        dilation: int = 1,
+        bias: bool = True,
+    ):
+        super().__init__(in_channels, out_channels, kernel_size, stride=stride, dilation=dilation, bias=bias)
+        self.cache_key = cache_key
+
+    @cached_property
+    def left_pad(self):
+        effective_kernel_size = (self.kernel_size[0] - 1) * self.dilation[0] + 1
+        return effective_kernel_size - self.stride[0]
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        padding_cache: AeroRealtimeAudioConv1dPaddingCache | None = None,
+    ) -> torch.Tensor:
+        if padding_cache is not None:
+            x = padding_cache.update(x, self.cache_key, self)
+        else:
+            x = nn.functional.pad(x, (self.left_pad, 0))
+
+        return super().forward(x)
+
+
+@use_kernel_forward_from_hub("RMSNorm")
+class AeroRealtimeAudioRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps: float = 1e-6) -> None:
+        """
+        AeroRealtimeAudioRMSNorm is equivalent to T5LayerNorm
+        """
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+@use_kernel_func_from_hub("rotary_pos_emb")
+def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding to the query and key tensors.
+
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """
+    This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
+    num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
+    """
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def _aero_audio_build_local_additive_mask(
+    q_len: int,
+    k_len: int,
+    window_left: int,
+    window_right: int,
+    key_padding_mask: torch.Tensor | None,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    q_idx = torch.arange(q_len, device=device)
+    k_idx = torch.arange(k_len, device=device)
+    delta = k_idx[None, :] - q_idx[:, None]
+    left_ok = torch.ones_like(delta, dtype=torch.bool) if window_left < 0 else (delta >= -window_left)
+    right_ok = torch.ones_like(delta, dtype=torch.bool) if window_right < 0 else (delta <= window_right)
+    allow = left_ok & right_ok
+    if key_padding_mask is not None:
+        allow = allow[None] & key_padding_mask.to(torch.bool)[:, None, :]
+    else:
+        allow = allow[None]
+    neg_inf = torch.finfo(dtype).min
+    mask = torch.zeros_like(allow, dtype=dtype).masked_fill(~allow, neg_inf)
+    return mask.unsqueeze(1)
+
+
+def _aero_audio_eager_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    dropout: float,
+    scaling: float,
+    window_left: int,
+    window_right: int,
+    **kwargs,
+):
+    _, _, q_len, _ = query.shape
+    k_len = key.shape[-2]
+    key_rep = repeat_kv(key, module.num_key_value_groups)
+    value_rep = repeat_kv(value, module.num_key_value_groups)
+
+    local_mask = _aero_audio_build_local_additive_mask(
+        q_len=q_len,
+        k_len=k_len,
+        window_left=window_left,
+        window_right=window_right,
+        key_padding_mask=attention_mask if (attention_mask is not None and attention_mask.dim() == 2) else None,
+        dtype=query.dtype,
+        device=query.device,
+    )
+    if attention_mask is not None and attention_mask.dim() == 4:
+        local_mask = local_mask + attention_mask
+
+    attn_weights = torch.matmul(query, key_rep.transpose(2, 3)) * scaling
+    attn_weights = attn_weights + local_mask
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
+    attn_output = torch.matmul(attn_weights, value_rep).transpose(1, 2).contiguous()
+    return attn_output, attn_weights
+
+
+def _aero_audio_sdpa_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    dropout: float,
+    scaling: float,
+    window_left: int,
+    window_right: int,
+    **kwargs,
+):
+    _, _, q_len, _ = query.shape
+    k_len = key.shape[-2]
+    key_rep = repeat_kv(key, module.num_key_value_groups)
+    value_rep = repeat_kv(value, module.num_key_value_groups)
+
+    local_mask = _aero_audio_build_local_additive_mask(
+        q_len=q_len,
+        k_len=k_len,
+        window_left=window_left,
+        window_right=window_right,
+        key_padding_mask=attention_mask if (attention_mask is not None and attention_mask.dim() == 2) else None,
+        dtype=query.dtype,
+        device=query.device,
+    )
+    if attention_mask is not None and attention_mask.dim() == 4:
+        local_mask = local_mask + attention_mask
+
+    attn_output = torch.nn.functional.scaled_dot_product_attention(
+        query,
+        key_rep,
+        value_rep,
+        attn_mask=local_mask,
+        dropout_p=dropout if module.training else 0.0,
+        scale=scaling,
+        is_causal=False,
+    )
+    return attn_output.transpose(1, 2).contiguous(), None
+
+
+def _aero_audio_fa_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    dropout: float,
+    scaling: float,
+    window_left: int,
+    window_right: int,
+    **kwargs,
+):
+    from flash_attn import flash_attn_func, flash_attn_varlen_func
+    from flash_attn.bert_padding import pad_input, unpad_input
+
+    q = query.transpose(1, 2)
+    k = key.transpose(1, 2)
+    v = value.transpose(1, 2)
+    bsz, q_len, _, _ = q.shape
+
+    causal = q_len == k.shape[1]
+    window = (window_left, window_right)
+
+    if attention_mask is None or attention_mask.dim() != 2:
+        attn_output = flash_attn_func(
+            q,
+            k,
+            v,
+            dropout_p=dropout if module.training else 0.0,
+            softmax_scale=scaling,
+            causal=causal,
+            window_size=window,
+        )
+    else:
+        q_unpad, indices_q, cu_q, max_q, *_ = unpad_input(q, attention_mask)
+        k_unpad, _, cu_k, max_k, *_ = unpad_input(k, attention_mask)
+        v_unpad, _, _, _, *_ = unpad_input(v, attention_mask)
+        out_unpad = flash_attn_varlen_func(
+            q_unpad,
+            k_unpad,
+            v_unpad,
+            cu_seqlens_q=cu_q,
+            cu_seqlens_k=cu_k,
+            max_seqlen_q=max_q,
+            max_seqlen_k=max_k,
+            dropout_p=dropout if module.training else 0.0,
+            softmax_scale=scaling,
+            causal=causal,
+            window_size=window,
+        )
+        attn_output = pad_input(out_unpad, indices_q, bsz, q_len)
+    return attn_output, None
+
+
+AERO_AUDIO_ATTENTION_FORWARDS = {
+    "eager": _aero_audio_eager_forward,
+    "sdpa": _aero_audio_sdpa_forward,
+    "flash_attention_2": _aero_audio_fa_forward,
+}
+
+
+@use_kernelized_func(apply_rotary_pos_emb)
+class AeroRealtimeAudioAttention(nn.Module):
+    """Multi-headed attention from 'Attention Is All You Need' paper"""
+
+    def __init__(self, config, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = config.attention_dropout
+        self.is_causal = True
+        self.q_proj = nn.Linear(config.hidden_size, config.num_attention_heads * self.head_dim, bias=True)
+        # similar to Whisper's original implementation the k projection does **not** have a bias
+        self.k_proj = nn.Linear(config.hidden_size, config.num_key_value_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(config.hidden_size, config.num_key_value_heads * self.head_dim, bias=True)
+        self.o_proj = nn.Linear(config.num_attention_heads * self.head_dim, config.hidden_size, bias=True)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+        past_key_values: Cache | None = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        if past_key_values is not None:
+            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+
+        attention_interface: Callable = AERO_AUDIO_ATTENTION_FORWARDS.get(
+            getattr(self.config, "_attn_implementation", "eager"), _aero_audio_eager_forward
+        )
+
+        attn_output, attn_weights = attention_interface(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            window_left=int(getattr(self.config, "attention_window_left", -1)),
+            window_right=int(getattr(self.config, "attention_window_right", -1)),
+            **kwargs,
+        )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+
+class AeroRealtimeAudioMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=True)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        return down_proj
+
+
+class AeroRealtimeAudioGeluMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+        self.act_fn = ACT2FN[config.activation_function]
+
+    def forward(self, x):
+        return self.fc2(self.act_fn(self.fc1(x)))
+
+
+def _build_norm(config) -> nn.Module:
+    norm_type = getattr(config, "norm_type", "rms_norm")
+    if norm_type == "rms_norm":
+        return AeroRealtimeAudioRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+    if norm_type == "layer_norm":
+        return nn.LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
+    raise ValueError(f"Unknown norm_type: {norm_type!r}")
+
+
+def _build_mlp(config) -> nn.Module:
+    mlp_type = getattr(config, "mlp_type", "swiglu")
+    if mlp_type == "swiglu":
+        return AeroRealtimeAudioMLP(config)
+    if mlp_type == "gelu":
+        return AeroRealtimeAudioGeluMLP(config)
+    raise ValueError(f"Unknown mlp_type: {mlp_type!r}")
+
+
+class AeroRealtimeAudioEmbedder(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.conv1 = AeroRealtimeAudioCausalConv1d(
+            config.num_mel_bins, config.hidden_size, kernel_size=3, cache_key="conv1"
+        )
+        self.conv2 = AeroRealtimeAudioCausalConv1d(
+            config.hidden_size, config.hidden_size, kernel_size=3, stride=2, cache_key="conv2"
+        )
+
+    def forward(self, input_features, padding_cache=None):
+        inputs_embeds = nn.functional.gelu(self.conv1(input_features, padding_cache=padding_cache))
+        inputs_embeds = nn.functional.gelu(self.conv2(inputs_embeds, padding_cache=padding_cache))
+        inputs_embeds = inputs_embeds.permute(0, 2, 1)
+        return inputs_embeds
+
+
+class AeroRealtimeAudioEncoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config, layer_idx: int):
+        super().__init__()
+        self.self_attn = AeroRealtimeAudioAttention(config, layer_idx)
+        self.self_attn_layer_norm = _build_norm(config)
+        self.activation_fn = ACT2FN[config.activation_function]
+        self.final_layer_norm = _build_norm(config)
+        self.mlp = _build_mlp(config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        use_cache: bool | None = False,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.FloatTensor`): attention mask of size
+                `(batch, 1, tgt_len, src_len)` where padding elements are indicated by very large negative values.
+            output_attentions (`bool`, *optional*):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+        """
+        residual = hidden_states
+        hidden_states = self.self_attn_layer_norm(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.final_layer_norm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class AeroRealtimeAudioPreTrainedModel(PreTrainedModel):
+    config: AeroRealtimeAudioEncoderConfig
+    base_model_prefix = "model"
+    input_modalities = ("audio", "text")
+    supports_gradient_checkpointing = True
+    _no_split_modules = None
+    _skip_keys_device_placement = "past_key_values"
+    _supports_flash_attn = True
+    _supports_sdpa = True
+    _supports_flex_attn = True
+    _supports_cache_class = True
+    _supports_attention_backend = True
+    # TODO: @eustlb, this should be enabled soon
+    _can_compile_fullgraph = False
+
+    @torch.no_grad()
+    def _init_weights(self, module):
+        super()._init_weights(module)
+
+
+class AeroRealtimeAudioEncoder(AeroRealtimeAudioPreTrainedModel):
+    """
+    Transformer encoder consisting of *config.encoder_layers* self attention layers. Each layer is a
+    [`AeroRealtimeAudioEncoderLayer`].
+
+    Args:
+        config: AeroRealtimeAudioEncoderConfig
+    """
+
+    config: AeroRealtimeAudioEncoderConfig
+    main_input_name = "input_features"
+    input_modalities = "audio"
+    _no_split_modules = ["AeroRealtimeAudioEncoderLayer"]
+    _can_record_outputs = {
+        "attentions": AeroRealtimeAudioAttention,
+        "hidden_states": AeroRealtimeAudioEncoderLayer,
+    }
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.embedder = AeroRealtimeAudioEmbedder(config)
+        self.layers = nn.ModuleList(
+            [AeroRealtimeAudioEncoderLayer(config, layer_idx) for layer_idx in range(config.encoder_layers)]
+        )
+        self.norm = _build_norm(config)
+        self.rotary_emb = AeroRealtimeAudioRotaryEmbedding(config=config)
+        self.gradient_checkpointing = False
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    @merge_with_config_defaults
+    @capture_outputs
+    def forward(
+        self,
+        input_features: torch.FloatTensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        padding_cache: AeroRealtimeAudioConv1dPaddingCache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        use_padding_cache: bool | None = None,
+        attention_mask: torch.Tensor | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> tuple | BaseModelOutputWithPooling:
+        r"""
+        padding_cache (`AeroRealtimeAudioConv1dPaddingCache`, *optional*):
+            Cache for padding in convolutional layers to maintain state across streaming chunks.
+        use_padding_cache (`bool`, *optional*):
+            Whether to use the padding cache.
+        """
+        if (input_features is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_features or inputs_embeds")
+
+        if use_padding_cache and padding_cache is None:
+            padding_cache = AeroRealtimeAudioConv1dPaddingCache()
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embedder(input_features, padding_cache)
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+
+        if position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            position_ids = position_ids.unsqueeze(0)
+
+        mask_function = create_causal_mask if self.config.sliding_window is None else create_sliding_window_causal_mask
+        causal_mask = mask_function(
+            config=self.config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+        )
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, position_ids=position_ids)
+
+        for encoder_layer in self.layers:
+            hidden_states = encoder_layer(
+                hidden_states,
+                attention_mask=causal_mask,
+                position_embeddings=position_embeddings,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                **kwargs,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return AeroRealtimeAudioEncoderOutput(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+            padding_cache=padding_cache,
         )

--- a/src/lmms_engine/models/aero_realtime/modeling_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/modeling_aero_realtime.py
@@ -952,6 +952,9 @@ def _aero_audio_eager_forward(
     key_rep = repeat_kv(key, module.num_key_value_groups)
     value_rep = repeat_kv(value, module.num_key_value_groups)
 
+    if bool(getattr(module.config, "is_causal", False)):
+        window_right = 0 if window_right < 0 else min(window_right, 0)
+
     local_mask = _aero_audio_build_local_additive_mask(
         q_len=q_len,
         k_len=k_len,
@@ -988,6 +991,9 @@ def _aero_audio_sdpa_forward(
     k_len = key.shape[-2]
     key_rep = repeat_kv(key, module.num_key_value_groups)
     value_rep = repeat_kv(value, module.num_key_value_groups)
+
+    if bool(getattr(module.config, "is_causal", False)):
+        window_right = 0 if window_right < 0 else min(window_right, 0)
 
     local_mask = _aero_audio_build_local_additive_mask(
         q_len=q_len,
@@ -1033,7 +1039,7 @@ def _aero_audio_fa_forward(
     v = value.transpose(1, 2)
     bsz, q_len, _, _ = q.shape
 
-    causal = q_len == k.shape[1]
+    causal = bool(getattr(module.config, "is_causal", False)) or (q_len == k.shape[1])
     window = (window_left, window_right)
 
     if attention_mask is None or attention_mask.dim() != 2:

--- a/src/lmms_engine/models/aero_realtime/modeling_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/modeling_aero_realtime.py
@@ -1,0 +1,707 @@
+# coding=utf-8
+# Copyright 2025 LMMs-Lab team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AeroRealtime model implementation.
+
+A multimodal model combining audio, vision, and language capabilities.
+Inspired by VoxtralRealtime but extended with vision support for
+image and video inputs.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.utils.checkpoint
+from torch import nn
+from transformers.activations import ACT2FN
+from transformers.generation import GenerationMixin
+from transformers.initialization import normal_, zeros_
+from transformers.modeling_outputs import ModelOutput
+from transformers.modeling_utils import PreTrainedModel
+from transformers.models.auto import AutoModel, AutoModelForCausalLM
+from transformers.utils import logging
+
+from ..common_ops.rope import qwen3_vl_get_rope_index
+from .backbone_registry import family_text_model_cls, family_vision_model_cls
+from .configuration_aero_realtime import AeroRealtimeConfig
+
+logger = logging.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Output dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AeroRealtimeCausalLMOutputWithPast(ModelOutput):
+    """
+    Output class for AeroRealtime causal language model.
+
+    Args:
+        loss (`torch.FloatTensor` of shape `(1,)`, *optional*):
+            Language modeling loss (for next-token prediction).
+        logits (`torch.FloatTensor` of shape `(batch_size, sequence_length, config.vocab_size)`):
+            Prediction scores of the language modeling head.
+        past_key_values (`tuple(tuple(torch.FloatTensor))`, *optional*):
+            Pre-computed hidden-states for sequential decoding.
+        hidden_states (`tuple(torch.FloatTensor)`, *optional*):
+            Hidden-states at each layer output.
+        attentions (`tuple(torch.FloatTensor)`, *optional*):
+            Attention weights after softmax.
+        audio_hidden_states (`torch.FloatTensor`, *optional*):
+            Audio hidden states produced by the audio encoder after projection.
+        vision_hidden_states (`torch.FloatTensor`, *optional*):
+            Vision hidden states produced by the vision encoder.
+    """
+
+    loss: Optional[torch.FloatTensor] = None
+    logits: torch.FloatTensor = None
+    past_key_values: Optional[List[torch.FloatTensor]] = None
+    hidden_states: Optional[Tuple[torch.FloatTensor]] = None
+    attentions: Optional[Tuple[torch.FloatTensor]] = None
+    audio_hidden_states: Optional[torch.FloatTensor] = None
+    vision_hidden_states: Optional[torch.FloatTensor] = None
+
+
+# ---------------------------------------------------------------------------
+# Audio multi-modal projector (same architecture as VoxtralRealtime)
+# ---------------------------------------------------------------------------
+
+
+class AeroRealtimeMultiModalProjector(nn.Module):
+    """Two-layer MLP projector that maps (downsampled) audio features to the
+    language model's hidden dimension.
+
+    Input dimension:  ``audio_config.hidden_size * downsample_factor``
+    Output dimension: ``text_config.hidden_size``
+
+    Architecture mirrors ``VoxtralRealtimeMultiModalProjector``: two linear
+    layers (no bias) with a configurable activation in between.
+    """
+
+    def __init__(self, config: AeroRealtimeConfig):
+        super().__init__()
+        audio_hidden_size = config.audio_hidden_size
+        text_hidden_size = config.text_config.hidden_size
+        downsample_factor = config.downsample_factor
+
+        self.linear_1 = nn.Linear(
+            audio_hidden_size * downsample_factor,
+            text_hidden_size,
+            bias=False,
+        )
+        self.act = ACT2FN[config.projector_hidden_act]
+        self.linear_2 = nn.Linear(
+            text_hidden_size,
+            text_hidden_size,
+            bias=False,
+        )
+
+    def forward(self, audio_features: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.linear_1(audio_features)
+        hidden_states = self.act(hidden_states)
+        hidden_states = self.linear_2(hidden_states)
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# PreTrainedModel base
+# ---------------------------------------------------------------------------
+
+
+class AeroRealtimePreTrainedModel(PreTrainedModel):
+    """Base class for AeroRealtime models, providing weight initialization
+    and a simple pre/post-init interface."""
+
+    config_class = AeroRealtimeConfig
+    base_model_prefix = ""
+    supports_gradient_checkpointing = True
+    _no_split_modules = [
+        "AeroRealtimeMultiModalProjector",
+    ]
+
+    def _init_weights(self, module):
+        std = (
+            self.config.text_config.initializer_range if hasattr(self.config.text_config, "initializer_range") else 0.02
+        )
+        if isinstance(module, nn.Linear):
+            normal_(module.weight, mean=0.0, std=std)
+            if module.bias is not None:
+                zeros_(module.bias)
+        elif isinstance(module, nn.Conv1d):
+            normal_(module.weight, mean=0.0, std=std)
+            if module.bias is not None:
+                zeros_(module.bias)
+        elif isinstance(module, nn.Embedding):
+            normal_(module.weight, mean=0.0, std=std)
+            if module.padding_idx is not None:
+                with torch.no_grad():
+                    module.weight.data[module.padding_idx].zero_()
+
+
+# ---------------------------------------------------------------------------
+# Main model
+# ---------------------------------------------------------------------------
+
+
+class AeroRealtimeForConditionalGeneration(AeroRealtimePreTrainedModel, GenerationMixin):
+    """AeroRealtime multimodal model for conditional generation.
+
+    Combines:
+    - An audio encoder tower (``audio_tower``)
+    - A vision encoder tower (``vision_tower``)
+    - A language model backbone (``language_model``, Qwen3VLTextModel)
+    - An LM head (``lm_head``)
+    - A 2-layer MLP audio projector (``multi_modal_projector``)
+
+    The vision tower (e.g. Qwen3 VL / Qwen3.5 VL) includes a built-in
+    merger/projector that already maps vision features to the text hidden
+    dimension, so no separate vision MLP is needed.
+    """
+
+    _supports_flash_attn_2 = True
+    _supports_flash_attn = True
+    _supports_sdpa = True
+    _tied_weights_keys = {"lm_head.weight": "language_model.embed_tokens.weight"}
+
+    def __init__(self, config: AeroRealtimeConfig):
+        super().__init__(config)
+
+        self.vocab_size = config.text_config.vocab_size
+
+        # --- Sub-modules ---
+        text_model_cls = family_text_model_cls(config.backbone_family)
+        vision_model_cls = family_vision_model_cls(config.backbone_family)
+        self.audio_tower = AutoModel.from_config(config.audio_config)
+        self.vision_tower = vision_model_cls._from_config(config.vision_config)
+        self.language_model = text_model_cls._from_config(config.text_config)
+        self.lm_head = nn.Linear(config.text_config.hidden_size, config.text_config.vocab_size, bias=False)
+        self.multi_modal_projector = AeroRealtimeMultiModalProjector(config)
+
+        # Cache audio tower type for dispatch
+        self.audio_tower_type = config.audio_config.model_type
+
+        self.post_init()
+
+        # Cached rope deltas for incremental position_ids during generation
+        self.rope_deltas = None
+
+    # --- Embedding accessors ---
+
+    def get_input_embeddings(self):
+        return self.language_model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.language_model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        attention_mask=None,
+        inputs_embeds=None,
+        position_ids=None,
+        use_cache=True,
+        is_first_iteration=False,
+        pixel_values=None,
+        pixel_values_videos=None,
+        image_grid_thw=None,
+        video_grid_thw=None,
+        # aero_realtime-specific kwargs (forwarded via **kwargs by super)
+        text_stream_ids=None,
+        input_features=None,
+        audio_attention_mask=None,
+        **kwargs,
+    ):
+        # Let the default GenerationMixin handle input_ids slicing,
+        # position_ids slicing, attention mask, and passthrough of extra
+        # kwargs -- mirrors official Qwen3VL.
+        model_inputs = super().prepare_inputs_for_generation(
+            input_ids,
+            past_key_values=past_key_values,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            pixel_values=pixel_values,
+            pixel_values_videos=pixel_values_videos,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            use_cache=use_cache,
+            is_first_iteration=is_first_iteration,
+            # pass aero-specific kwargs so super forwards them
+            text_stream_ids=text_stream_ids,
+            input_features=input_features,
+            audio_attention_mask=audio_attention_mask,
+            **kwargs,
+        )
+
+        # After the first iteration the multimodal features have been
+        # consumed and cached in KV-cache — clear them to avoid
+        # recomputation (same pattern as official Qwen3VL).
+        if not is_first_iteration and use_cache:
+            model_inputs["pixel_values"] = None
+            model_inputs["pixel_values_videos"] = None
+            model_inputs["input_features"] = None
+            model_inputs["audio_attention_mask"] = None
+            # text_stream_ids only meaningful during prefill
+            model_inputs["text_stream_ids"] = None
+
+        return model_inputs
+
+    def _prepare_position_ids_for_generation(self, inputs_tensor, model_kwargs):
+        """Compute 3D MROPE position ids, aligned with official Qwen3VL."""
+
+        # Standard 2D text positions from parent
+        text_positions = super()._prepare_position_ids_for_generation(inputs_tensor, model_kwargs)
+
+        # Continuing generation from past KV — use cached rope_deltas
+        past_length = 0
+        if (cache := model_kwargs.get("past_key_values")) is not None:
+            past_length = cache.get_seq_length()
+        if past_length != 0 and self.rope_deltas is not None:
+            position_ids = text_positions[None, ...] + self.rope_deltas
+            return position_ids
+
+        # First call: compute 3D vision positions via the shared rope helper
+        if "input_ids" in model_kwargs and model_kwargs["input_ids"].shape[1] > 0:
+            inputs_tensor = model_kwargs["input_ids"]
+
+        is_input_ids = len(inputs_tensor.shape) == 2 and inputs_tensor.dtype in [torch.int, torch.long]
+        has_vision = model_kwargs.get("image_grid_thw") is not None or model_kwargs.get("video_grid_thw") is not None
+
+        if is_input_ids and has_vision:
+            vision_positions, rope_deltas = qwen3_vl_get_rope_index(
+                self,
+                inputs_tensor,
+                image_grid_thw=model_kwargs.get("image_grid_thw"),
+                video_grid_thw=model_kwargs.get("video_grid_thw"),
+                attention_mask=model_kwargs.get("attention_mask"),
+            )
+            self.rope_deltas = rope_deltas
+        else:
+            vision_positions = text_positions.unsqueeze(0).expand(3, -1, -1)
+            self.rope_deltas = torch.zeros(
+                inputs_tensor.shape[0],
+                1,
+                dtype=torch.long,
+                device=inputs_tensor.device,
+            )
+
+        # Concatenate text + vision → [4, B, S]
+        text_positions = text_positions[None, ...]
+        position_ids = torch.cat([text_positions, vision_positions], dim=0)
+
+        return position_ids
+
+    # Weight tying is handled by the parent class via ``_tied_weights_keys``
+    # which maps ``lm_head.weight`` -> ``language_model.embed_tokens.weight``.
+
+    # --- Feature extraction helpers ---
+
+    def get_vision_features(
+        self,
+        pixel_values: torch.FloatTensor,
+        grid_thw: Optional[torch.LongTensor] = None,
+    ) -> torch.Tensor:
+        """Extract vision features via the vision tower.
+
+        The vision tower (e.g. Qwen3 VL) includes a built-in merger that
+        projects features to ``text_config.hidden_size``.  The merged output
+        is returned from ``pooler_output`` (post-merger), not
+        ``last_hidden_state`` (pre-merger).
+
+        Args:
+            pixel_values: Pixel values, shape depends on the vision tower.
+                Typically ``[total_patches, C, H, W]`` (flat across batch).
+            grid_thw: Grid of ``(temporal, height, width)`` per image/video.
+                Shape ``[num_images_or_videos, 3]``.
+
+        Returns:
+            Vision features of shape ``[total_merged_tokens, hidden_dim]``
+            where ``hidden_dim = text_config.hidden_size`` and
+            ``total_merged_tokens = total_patches / merge_size^2``.
+        """
+        if grid_thw is not None:
+            vision_outputs = self.vision_tower(pixel_values, grid_thw=grid_thw)
+        else:
+            vision_outputs = self.vision_tower(pixel_values)
+
+        if isinstance(vision_outputs, torch.Tensor):
+            return vision_outputs
+
+        # Prefer pooler_output (post-merger) over last_hidden_state (pre-merger)
+        if hasattr(vision_outputs, "pooler_output") and vision_outputs.pooler_output is not None:
+            return vision_outputs.pooler_output
+
+        return vision_outputs.last_hidden_state
+
+    def get_audio_features(
+        self,
+        input_features: torch.FloatTensor,
+        audio_attention_mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Extract audio features via the audio tower, downsample, and project.
+
+        Following VoxtralRealtime's approach:
+        1. Run audio through the audio encoder tower.
+        2. Reshape by concatenating ``downsample_factor`` consecutive frames.
+        3. Project through the 2-layer MLP (``multi_modal_projector``).
+
+        Args:
+            input_features: Mel spectrogram features.
+                Shape ``[batch_size, num_mel_bins, mel_seq_len]`` or as
+                expected by the audio tower.
+            audio_attention_mask: Attention mask at mel-frame level.
+                Shape ``[batch_size, mel_seq_len]``.
+
+        Returns:
+            Tuple of:
+            - Projected audio features of shape
+              ``[batch_size, num_audio_tokens, hidden_dim]``
+              where ``num_audio_tokens = encoder_seq_len / downsample_factor``
+              and ``hidden_dim = text_config.hidden_size``.
+            - ``audio_output_lengths`` of shape ``[batch_size]``, the number
+              of valid (unpadded) encoder output tokens per sample.
+        """
+        # Compute audio feature/output lengths via encoder's own method
+        audio_output_lengths = None
+        encoder_kwargs = {}
+
+        if audio_attention_mask is not None and hasattr(self.audio_tower, "_get_feat_extract_output_lengths"):
+            mel_lengths = audio_attention_mask.sum(-1)
+            audio_feat_lengths, audio_output_lengths = self.audio_tower._get_feat_extract_output_lengths(mel_lengths)
+
+            # Qwen2Audio encoder needs a custom 4D attention mask
+            if self.audio_tower_type == "qwen2_audio_encoder":
+                encoder_kwargs["attention_mask"] = self._build_qwen2_audio_attention_mask(
+                    input_features, audio_feat_lengths
+                )
+
+        audio_outputs = self.audio_tower(input_features=input_features, **encoder_kwargs)
+
+        if isinstance(audio_outputs, torch.Tensor):
+            audio_hidden_states = audio_outputs
+        else:
+            audio_hidden_states = audio_outputs.last_hidden_state
+
+        # Downsample: concatenate `downsample_factor` consecutive frames
+        # [B, seq_len, audio_hidden] -> [B, seq_len/df, audio_hidden * df]
+        # Truncate seq_len to nearest multiple of downsample_factor
+        df = self.config.downsample_factor
+        seq_len = audio_hidden_states.shape[1]
+        usable_len = (seq_len // df) * df
+        audio_hidden_states = audio_hidden_states[:, :usable_len, :]
+
+        audio_hidden_states = audio_hidden_states.reshape(
+            audio_hidden_states.shape[0],
+            -1,
+            self.config.audio_hidden_size * df,
+        )
+
+        # Project to text hidden dim
+        audio_features = self.multi_modal_projector(audio_hidden_states)
+
+        # Adjust output lengths for downsample factor
+        if audio_output_lengths is not None:
+            audio_output_lengths = audio_output_lengths // self.config.downsample_factor
+
+        return audio_features, audio_output_lengths
+
+    def _build_qwen2_audio_attention_mask(
+        self,
+        input_features: torch.Tensor,
+        audio_feat_lengths: torch.Tensor,
+    ) -> torch.Tensor:
+        """Build the 4D attention mask expected by the Qwen2Audio encoder.
+
+        The encoder applies two downsampling stages (conv2 stride=2, avg_pool
+        stride=2), so the mask is built at the post-conv2 sequence length.
+
+        Args:
+            input_features: ``[batch_size, num_mel_bins, mel_seq_len]``
+            audio_feat_lengths: ``[batch_size]`` -- number of valid tokens
+                after the first conv2 downsampling.
+
+        Returns:
+            4D float attention mask of shape
+            ``[batch_size, 1, max_seq_len, max_seq_len]`` with ``-inf``
+            at padding positions.
+        """
+        batch_size = input_features.shape[0]
+        max_mel_seq_len = input_features.shape[-1]
+        max_seq_len = (max_mel_seq_len - 2) // 2 + 1
+
+        seq_range = (
+            torch.arange(0, max_seq_len, dtype=audio_feat_lengths.dtype, device=audio_feat_lengths.device)
+            .unsqueeze(0)
+            .expand(batch_size, max_seq_len)
+        )
+        lengths_expand = audio_feat_lengths.unsqueeze(1).expand(batch_size, max_seq_len)
+        padding_mask = seq_range >= lengths_expand
+
+        attention_mask = padding_mask.view(batch_size, 1, 1, max_seq_len).expand(
+            batch_size, 1, max_seq_len, max_seq_len
+        )
+        attention_mask = attention_mask.to(
+            dtype=self.audio_tower.conv1.weight.dtype,
+            device=self.audio_tower.conv1.weight.device,
+        )
+        attention_mask = attention_mask.clone()
+        attention_mask[padding_mask.view(batch_size, 1, 1, max_seq_len).expand_as(attention_mask)] = float("-inf")
+        return attention_mask
+
+    @staticmethod
+    def _unpad_audio_features(
+        audio_features: torch.Tensor,
+        audio_output_lengths: torch.Tensor,
+    ) -> torch.Tensor:
+        """Remove padding from batched audio features and flatten.
+
+        Args:
+            audio_features: ``[batch_size, max_seq_len, hidden_dim]``
+            audio_output_lengths: ``[batch_size]`` -- valid token count per sample.
+
+        Returns:
+            Flat tensor ``[total_valid_tokens, hidden_dim]``.
+        """
+        unpadded = [feat[:length] for feat, length in zip(audio_features, audio_output_lengths)]
+        return torch.cat(unpadded, dim=0)
+
+    # --- Forward ---
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        text_stream_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        # Audio inputs
+        input_features: Optional[torch.FloatTensor] = None,
+        audio_attention_mask: Optional[torch.Tensor] = None,
+        # Vision inputs — images
+        pixel_values: Optional[torch.FloatTensor] = None,
+        image_grid_thw: Optional[torch.LongTensor] = None,
+        # Vision inputs — videos
+        pixel_values_videos: Optional[torch.FloatTensor] = None,
+        video_grid_thw: Optional[torch.LongTensor] = None,
+        # Standard args
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        **kwargs,
+    ) -> Union[Tuple, AeroRealtimeCausalLMOutputWithPast]:
+        """Forward pass for AeroRealtime.
+
+        Audio and video are kept as **separate** token streams in the input
+        sequence (per-chunk envelope ``[VS][video_pad×S][VE][AS]
+        [audio_pad×N][AE]``) so time alignment is expressed entirely through token
+        order and RoPE.  Vision features replace vision placeholders; audio
+        features are added to the realtime text stream on audio placeholders.
+
+        Modality combinations:
+
+        **Image mode** (``pixel_values`` + ``image_grid_thw``):
+            Vision features are scattered (replace) at ``image_token_index``
+            positions.  ``text_stream_ids`` is not used.
+
+        **Video mode** (``pixel_values_videos`` + ``video_grid_thw``):
+            Video features are scattered (replace) at
+            ``video_token_index`` positions.
+
+        **Audio mode** (``input_features``):
+            Audio features are **added** to embeddings at
+            ``audio_token_index`` positions.
+
+        **Video + Audio**: video placeholders receive pure vision features.
+        ``text_stream_ids`` carries realtime markers (``<|rt_speak|>``,
+        ``<|rt_start|>``, ``<|rt_end|>``, and speech text) only at audio
+        positions, where audio features are added to the realtime text embeddings.
+
+        Pipeline:
+            1. Embed ``text_stream_ids`` (if provided) or ``input_ids``.
+            2. Image features → scatter at ``image_token_index``.
+            3. Video features → scatter at ``video_token_index``.
+            4. Audio features → add at ``audio_token_index``.
+            5. Forward through the language model.
+
+        Args:
+            input_ids: Token ids with placeholder tokens for vision/audio.
+                Shape ``[batch_size, seq_len]``.  Used to determine the
+                position masks for image/video/audio features.
+            text_stream_ids: Parallel text-stream token ids.
+                Shape ``[batch_size, seq_len]``.  At audio positions contains
+                ``<|rt_pad|>``, ``<|rt_speak|>``, speech boundary tokens, or
+                actual text tokens; mirrors ``input_ids`` elsewhere.
+                If not provided, falls back to ``input_ids``.
+            pixel_values: Image pixel values (flat across batch).
+            image_grid_thw: Grid info per image. ``[num_images, 3]``.
+            pixel_values_videos: Video pixel values (flat across batch).
+            video_grid_thw: Grid info per video. ``[num_videos, 3]``.
+            input_features: Audio mel spectrogram features.
+                Shape ``[batch_size, num_mel_bins, mel_seq_len]``.
+            audio_attention_mask: Mel-level attention mask for audio.
+                Shape ``[batch_size, mel_seq_len]``.
+            labels: Target token ids for loss computation. ``-100`` ignored.
+        """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        # Determine which token ids to use for embedding
+        # text_stream_ids provides the realtime text tokens at audio positions.
+        # input_ids is used for determining modality placeholder masks.
+        embed_ids = text_stream_ids if text_stream_ids is not None else input_ids
+
+        # ----------------------------------------------------------------
+        # 1. Text embeddings (from text_stream_ids or input_ids)
+        # ----------------------------------------------------------------
+        if inputs_embeds is None:
+            inputs_embeds = self.get_input_embeddings()(embed_ids)
+
+        # ----------------------------------------------------------------
+        # 2. Image features — extract and scatter at image_token_index
+        #    (image mode is unchanged — uses scatter/replace)
+        # ----------------------------------------------------------------
+        if pixel_values is not None:
+            image_features = self.get_vision_features(pixel_values, grid_thw=image_grid_thw)
+
+            image_mask = input_ids == self.config.image_token_index
+            n_image_tokens = image_mask.sum().item()
+            n_image_features = image_features.shape[0]
+            if n_image_tokens != n_image_features:
+                raise ValueError(
+                    f"Image token count ({n_image_tokens}) does not match " f"image feature count ({n_image_features})."
+                )
+
+            image_mask_expanded = image_mask.unsqueeze(-1).expand_as(inputs_embeds)
+            inputs_embeds = inputs_embeds.masked_scatter(
+                image_mask_expanded,
+                image_features.to(inputs_embeds.dtype),
+            )
+
+        # ----------------------------------------------------------------
+        # 3. Video features — extract (scatter happens below)
+        # ----------------------------------------------------------------
+        video_features = None
+        if pixel_values_videos is not None:
+            video_features = self.get_vision_features(pixel_values_videos, grid_thw=video_grid_thw)
+
+        # ----------------------------------------------------------------
+        # 4. Audio features — extract, downsample, project
+        # ----------------------------------------------------------------
+        audio_features = None
+        audio_output_lengths = None
+        audio_features_flat = None
+        if input_features is not None:
+            audio_features, audio_output_lengths = self.get_audio_features(
+                input_features, audio_attention_mask=audio_attention_mask
+            )
+            # Flatten, removing padding if output lengths are available
+            if audio_output_lengths is not None:
+                audio_features_flat = self._unpad_audio_features(audio_features, audio_output_lengths)
+            else:
+                audio_features_flat = audio_features.reshape(-1, audio_features.shape[-1])
+
+        # ----------------------------------------------------------------
+        # 5. Scatter video features and add audio features to text-stream embeddings.
+        #    Realtime text conditioning lives only on the audio timeline.
+        # ----------------------------------------------------------------
+
+        # 5a. Video features -> scatter at video_token_index positions
+        if video_features is not None:
+            video_mask = input_ids == self.config.video_token_index
+            n_video_tokens = video_mask.sum().item()
+            n_video_features = video_features.shape[0]
+            if n_video_tokens != n_video_features:
+                raise ValueError(
+                    f"Video token count ({n_video_tokens}) does not match " f"video feature count ({n_video_features})."
+                )
+
+            video_mask_expanded = video_mask.unsqueeze(-1).expand_as(inputs_embeds)
+            inputs_embeds = inputs_embeds.masked_scatter(
+                video_mask_expanded,
+                video_features.to(inputs_embeds.dtype),
+            )
+
+        # 5b. Audio features -> add at audio_token_index positions
+        if audio_features_flat is not None:
+            audio_mask = input_ids == self.config.audio_token_index
+            n_audio_tokens = audio_mask.sum().item()
+            n_audio_features = audio_features_flat.shape[0]
+            if n_audio_tokens != n_audio_features:
+                raise ValueError(
+                    f"Audio token count ({n_audio_tokens}) does not match " f"audio feature count ({n_audio_features})."
+                )
+
+            audio_mask_flat = audio_mask.reshape(-1)
+            inputs_embeds_flat = inputs_embeds.reshape(-1, inputs_embeds.shape[-1])
+            inputs_embeds_flat[audio_mask_flat] = inputs_embeds_flat[audio_mask_flat] + audio_features_flat.to(
+                inputs_embeds.dtype
+            )
+            inputs_embeds = inputs_embeds_flat.reshape(inputs_embeds.shape)
+
+        # ----------------------------------------------------------------
+        # 6. Language model forward + LM head
+        # ----------------------------------------------------------------
+        # Qwen3VLTextModel returns BaseModelOutputWithPast (hidden states,
+        # no logits/loss).  We apply lm_head and compute loss here.
+        outputs = self.language_model(
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=True,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        logits = self.lm_head(hidden_states)
+
+        # Compute loss if labels are provided
+        loss = None
+        if labels is not None:
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            loss_fct = nn.CrossEntropyLoss()
+            shift_logits = shift_logits.view(-1, self.vocab_size)
+            shift_labels = shift_labels.view(-1)
+            shift_labels = shift_labels.to(shift_logits.device)
+            loss = loss_fct(shift_logits, shift_labels)
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return AeroRealtimeCausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            audio_hidden_states=audio_features_flat,
+            vision_hidden_states=video_features,
+        )

--- a/src/lmms_engine/models/aero_realtime/modeling_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/modeling_aero_realtime.py
@@ -805,7 +805,7 @@ class AeroRealtimeAudioRotaryEmbedding(nn.Module):
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
-class AeroRealtimeAudioCausalConv1d(nn.Conv1d):
+class AeroRealtimeAudioConv1d(nn.Conv1d):
     def __init__(
         self,
         in_channels: int,
@@ -815,9 +815,13 @@ class AeroRealtimeAudioCausalConv1d(nn.Conv1d):
         stride: int = 1,
         dilation: int = 1,
         bias: bool = True,
+        padding_mode: str = "causal",
     ):
         super().__init__(in_channels, out_channels, kernel_size, stride=stride, dilation=dilation, bias=bias)
         self.cache_key = cache_key
+        if padding_mode not in ("causal", "symmetric"):
+            raise ValueError(f"padding_mode must be 'causal' or 'symmetric', got {padding_mode}")
+        self.padding_mode_ = padding_mode
 
     @cached_property
     def left_pad(self):
@@ -829,7 +833,11 @@ class AeroRealtimeAudioCausalConv1d(nn.Conv1d):
         x: torch.Tensor,
         padding_cache: AeroRealtimeAudioConv1dPaddingCache | None = None,
     ) -> torch.Tensor:
-        if padding_cache is not None:
+        if self.padding_mode_ == "symmetric":
+            # Symmetric padding ignores padding_cache (chunks are independent).
+            pad = self.left_pad // 2
+            x = nn.functional.pad(x, (pad, self.left_pad - pad))
+        elif padding_cache is not None:
             x = padding_cache.update(x, self.cache_key, self)
         else:
             x = nn.functional.pad(x, (self.left_pad, 0))
@@ -1080,8 +1088,11 @@ class AeroRealtimeAudioAttention(nn.Module):
         self.attention_dropout = config.attention_dropout
         self.is_causal = True
         self.q_proj = nn.Linear(config.hidden_size, config.num_attention_heads * self.head_dim, bias=True)
-        # similar to Whisper's original implementation the k projection does **not** have a bias
-        self.k_proj = nn.Linear(config.hidden_size, config.num_key_value_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=bool(getattr(config, "k_proj_bias", False)),
+        )
         self.v_proj = nn.Linear(config.hidden_size, config.num_key_value_heads * self.head_dim, bias=True)
         self.o_proj = nn.Linear(config.num_attention_heads * self.head_dim, config.hidden_size, bias=True)
 
@@ -1178,11 +1189,20 @@ class AeroRealtimeAudioEmbedder(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.config = config
-        self.conv1 = AeroRealtimeAudioCausalConv1d(
-            config.num_mel_bins, config.hidden_size, kernel_size=3, cache_key="conv1"
+        self.conv1 = AeroRealtimeAudioConv1d(
+            config.num_mel_bins,
+            config.hidden_size,
+            kernel_size=3,
+            cache_key="conv1",
+            padding_mode=config.conv_padding,
         )
-        self.conv2 = AeroRealtimeAudioCausalConv1d(
-            config.hidden_size, config.hidden_size, kernel_size=3, stride=2, cache_key="conv2"
+        self.conv2 = AeroRealtimeAudioConv1d(
+            config.hidden_size,
+            config.hidden_size,
+            kernel_size=3,
+            stride=2,
+            cache_key="conv2",
+            padding_mode=config.conv_padding,
         )
 
     def forward(self, input_features, padding_cache=None):

--- a/src/lmms_engine/models/aero_realtime/monkey_patch.py
+++ b/src/lmms_engine/models/aero_realtime/monkey_patch.py
@@ -71,11 +71,7 @@ def apply_liger_kernel_to_aero_realtime(
 
 @MONKEY_PATCHER.register("aero_realtime", "rmpad")
 def apply_rmpad_to_aero_realtime(model: PreTrainedModel = None) -> None:
-    """Apply rmpad ops to AeroRealtime's language sub-model + bind aero's
-    rmpad-flavoured lce forward.
-
-    VoxtralRealtimeEncoder runs its own native forward — no rmpad patches
-    applied to the audio tower (future optimization PR)."""
+    """Apply rmpad ops to AeroRealtime's language and audio towers."""
     from .modeling_aero_realtime import AeroRealtimeForConditionalGeneration
 
     if model is None:
@@ -88,6 +84,12 @@ def apply_rmpad_to_aero_realtime(model: PreTrainedModel = None) -> None:
 
     # 1. Patch language sub-model — rmpad-only
     rmpad_fn(model=model.language_model)
+
+    from lmms_engine.models.voxtral_realtime.monkey_patch import (
+        apply_rmpad_to_voxtral_realtime,
+    )
+
+    apply_rmpad_to_voxtral_realtime(model=model.audio_tower)
 
     # 2. Bind aero's rmpad forward (same lce forward — already rmpad-aware)
     from .aero_realtime_liger import aero_realtime_lce_forward

--- a/src/lmms_engine/models/aero_realtime/monkey_patch.py
+++ b/src/lmms_engine/models/aero_realtime/monkey_patch.py
@@ -1,0 +1,93 @@
+"""Monkey patches for AeroRealtime training (OV2-style split).
+
+The patcher is split into two independent entries, mirroring
+``llava_onevision2`` (PR #170) and ``qwen3_5_moe`` (PR #171):
+
+- ``liger`` — RoPE / RMSNorm / SwiGLU + binds aero's lce_forward
+- ``rmpad`` — text/vision/audio rmpad ops + binds aero's rmpad forward
+
+When both run (runner ordering ``["liger", "rmpad"]``), rmpad wins for
+``forward`` rebinding, yielding rmpad + fused-LCE training.
+
+Family dispatch lives in ``backbone_registry.family_liger_fn`` /
+``family_rmpad_fn``.
+"""
+
+from transformers import PreTrainedModel
+
+from lmms_engine.models.monkey_patch import MONKEY_PATCHER
+
+from .backbone_registry import family_liger_fn, family_rmpad_fn
+
+
+@MONKEY_PATCHER.register("aero_realtime", "liger")
+def apply_liger_kernel_to_aero_realtime(
+    rope: bool = True,
+    cross_entropy: bool = False,
+    fused_linear_cross_entropy: bool = False,
+    rms_norm: bool = True,
+    swiglu: bool = True,
+    model: PreTrainedModel = None,
+) -> None:
+    """Apply Liger kernels to AeroRealtime's language + audio sub-models."""
+    from .modeling_aero_realtime import AeroRealtimeForConditionalGeneration
+
+    if model is None:
+        raise ValueError("apply_liger_kernel_to_aero_realtime requires model=...")
+    if not isinstance(model, AeroRealtimeForConditionalGeneration):
+        raise TypeError(f"Expected AeroRealtimeForConditionalGeneration, got {type(model)}")
+
+    from lmms_engine.models.qwen2_audio.monkey_patch import (
+        apply_liger_kernel_to_qwen2_audio,
+    )
+
+    family = model.config.backbone_family
+    liger_fn = family_liger_fn(family)
+
+    # 1. Patch language sub-model
+    liger_fn(
+        model=model.language_model,
+        rope=rope,
+        rms_norm=rms_norm,
+        swiglu=swiglu,
+        cross_entropy=cross_entropy,
+        fused_linear_cross_entropy=fused_linear_cross_entropy,
+    )
+
+    # 2. Patch audio sub-model
+    apply_liger_kernel_to_qwen2_audio(model=model.audio_tower)
+
+    # 3. Bind aero's lce-flavoured forward
+    from .aero_realtime_liger import aero_realtime_lce_forward
+
+    AeroRealtimeForConditionalGeneration.forward = aero_realtime_lce_forward
+
+
+@MONKEY_PATCHER.register("aero_realtime", "rmpad")
+def apply_rmpad_to_aero_realtime(model: PreTrainedModel = None) -> None:
+    """Apply rmpad ops to AeroRealtime's language + audio sub-models +
+    bind aero's rmpad-flavoured lce forward."""
+    from .modeling_aero_realtime import AeroRealtimeForConditionalGeneration
+
+    if model is None:
+        raise ValueError("apply_rmpad_to_aero_realtime requires model=...")
+    if not isinstance(model, AeroRealtimeForConditionalGeneration):
+        raise TypeError(f"Expected AeroRealtimeForConditionalGeneration, got {type(model)}")
+
+    from lmms_engine.models.qwen2_audio.monkey_patch import (
+        apply_liger_kernel_to_qwen2_audio,
+    )
+
+    family = model.config.backbone_family
+    rmpad_fn = family_rmpad_fn(family)
+
+    # 1. Patch language sub-model — rmpad-only
+    rmpad_fn(model=model.language_model)
+
+    # 2. Patch audio sub-model with rmpad
+    apply_liger_kernel_to_qwen2_audio(model=model.audio_tower, use_rmpad=True)
+
+    # 3. Bind aero's rmpad forward (same lce forward — already rmpad-aware)
+    from .aero_realtime_liger import aero_realtime_lce_forward
+
+    AeroRealtimeForConditionalGeneration.forward = aero_realtime_lce_forward

--- a/src/lmms_engine/models/aero_realtime/monkey_patch.py
+++ b/src/lmms_engine/models/aero_realtime/monkey_patch.py
@@ -17,7 +17,11 @@ from transformers import PreTrainedModel
 
 from lmms_engine.models.monkey_patch import MONKEY_PATCHER
 
-from .backbone_registry import family_liger_fn, family_rmpad_fn
+from .backbone_registry import (
+    family_liger_fn,
+    family_rmpad_fn,
+    family_vit_frame_parallel_fn,
+)
 
 
 @MONKEY_PATCHER.register("aero_realtime", "liger")
@@ -29,17 +33,16 @@ def apply_liger_kernel_to_aero_realtime(
     swiglu: bool = True,
     model: PreTrainedModel = None,
 ) -> None:
-    """Apply Liger kernels to AeroRealtime's language + audio sub-models."""
+    """Apply Liger kernels to AeroRealtime's language sub-model.
+
+    VoxtralRealtimeEncoder runs its own native forward — no liger patches
+    applied to the audio tower (future optimization PR)."""
     from .modeling_aero_realtime import AeroRealtimeForConditionalGeneration
 
     if model is None:
         raise ValueError("apply_liger_kernel_to_aero_realtime requires model=...")
     if not isinstance(model, AeroRealtimeForConditionalGeneration):
         raise TypeError(f"Expected AeroRealtimeForConditionalGeneration, got {type(model)}")
-
-    from lmms_engine.models.qwen2_audio.monkey_patch import (
-        apply_liger_kernel_to_qwen2_audio,
-    )
 
     family = model.config.backbone_family
     liger_fn = family_liger_fn(family)
@@ -54,10 +57,7 @@ def apply_liger_kernel_to_aero_realtime(
         fused_linear_cross_entropy=fused_linear_cross_entropy,
     )
 
-    # 2. Patch audio sub-model
-    apply_liger_kernel_to_qwen2_audio(model=model.audio_tower)
-
-    # 3. Bind aero's lce-flavoured forward
+    # 2. Bind aero's lce-flavoured forward
     from .aero_realtime_liger import aero_realtime_lce_forward
 
     AeroRealtimeForConditionalGeneration.forward = aero_realtime_lce_forward
@@ -65,8 +65,11 @@ def apply_liger_kernel_to_aero_realtime(
 
 @MONKEY_PATCHER.register("aero_realtime", "rmpad")
 def apply_rmpad_to_aero_realtime(model: PreTrainedModel = None) -> None:
-    """Apply rmpad ops to AeroRealtime's language + audio sub-models +
-    bind aero's rmpad-flavoured lce forward."""
+    """Apply rmpad ops to AeroRealtime's language sub-model + bind aero's
+    rmpad-flavoured lce forward.
+
+    VoxtralRealtimeEncoder runs its own native forward — no rmpad patches
+    applied to the audio tower (future optimization PR)."""
     from .modeling_aero_realtime import AeroRealtimeForConditionalGeneration
 
     if model is None:
@@ -74,20 +77,42 @@ def apply_rmpad_to_aero_realtime(model: PreTrainedModel = None) -> None:
     if not isinstance(model, AeroRealtimeForConditionalGeneration):
         raise TypeError(f"Expected AeroRealtimeForConditionalGeneration, got {type(model)}")
 
-    from lmms_engine.models.qwen2_audio.monkey_patch import (
-        apply_liger_kernel_to_qwen2_audio,
-    )
-
     family = model.config.backbone_family
     rmpad_fn = family_rmpad_fn(family)
 
     # 1. Patch language sub-model — rmpad-only
     rmpad_fn(model=model.language_model)
 
-    # 2. Patch audio sub-model with rmpad
-    apply_liger_kernel_to_qwen2_audio(model=model.audio_tower, use_rmpad=True)
-
-    # 3. Bind aero's rmpad forward (same lce forward — already rmpad-aware)
+    # 2. Bind aero's rmpad forward (same lce forward — already rmpad-aware)
     from .aero_realtime_liger import aero_realtime_lce_forward
 
     AeroRealtimeForConditionalGeneration.forward = aero_realtime_lce_forward
+
+
+@MONKEY_PATCHER.register("aero_realtime", "vit_frame_parallel")
+def apply_vit_frame_parallel_to_aero_realtime(model: PreTrainedModel = None, **kwargs) -> None:
+    """Wrap the family's VisionModel.forward with frame-parallel dispatch.
+
+    Class-level patch — delegates to the inner family's frame-parallel fn
+    (currently only ``qwen3_5`` supports this). For families without a
+    frame-parallel implementation this is a no-op.
+
+    Aero's ``model.vision_tower`` is an instance of the family's VisionModel
+    class, so patching the class also patches this instance.
+    """
+    from loguru import logger
+
+    from .modeling_aero_realtime import AeroRealtimeForConditionalGeneration
+
+    if model is None:
+        raise ValueError("apply_vit_frame_parallel_to_aero_realtime requires model=...")
+    if not isinstance(model, AeroRealtimeForConditionalGeneration):
+        raise TypeError(f"Expected AeroRealtimeForConditionalGeneration, got {type(model)}")
+
+    family = model.config.backbone_family
+    fp_fn = family_vit_frame_parallel_fn(family)
+    if fp_fn is None:
+        logger.info(f"vit_frame_parallel: backbone_family={family} has no frame-parallel ViT impl, skipping")
+        return
+    # Inner family fns ignore the ``model`` arg (class-level patch).
+    fp_fn(model=model.vision_tower, **kwargs)

--- a/src/lmms_engine/models/aero_realtime/monkey_patch.py
+++ b/src/lmms_engine/models/aero_realtime/monkey_patch.py
@@ -85,11 +85,21 @@ def apply_rmpad_to_aero_realtime(model: PreTrainedModel = None) -> None:
     # 1. Patch language sub-model — rmpad-only
     rmpad_fn(model=model.language_model)
 
-    from lmms_engine.models.voxtral_realtime.monkey_patch import (
-        apply_rmpad_to_voxtral_realtime,
+    from lmms_engine.models.aero_realtime.aero_realtime_audio_ops import (
+        aero_realtime_attention_forward,
+        aero_realtime_encoder_forward,
     )
 
-    apply_rmpad_to_voxtral_realtime(model=model.audio_tower)
+    from .modeling_aero_realtime import (
+        AeroRealtimeAudioAttention,
+        AeroRealtimeAudioEncoder,
+    )
+
+    if not isinstance(model.audio_tower, AeroRealtimeAudioEncoder):
+        raise TypeError(f"Expected AeroRealtimeAudioEncoder, got {type(model.audio_tower)}")
+
+    AeroRealtimeAudioEncoder.forward = aero_realtime_encoder_forward
+    AeroRealtimeAudioAttention.forward = aero_realtime_attention_forward
 
     # 2. Bind aero's rmpad forward (same lce forward — already rmpad-aware)
     from .aero_realtime_liger import aero_realtime_lce_forward

--- a/src/lmms_engine/models/aero_realtime/monkey_patch.py
+++ b/src/lmms_engine/models/aero_realtime/monkey_patch.py
@@ -47,6 +47,12 @@ def apply_liger_kernel_to_aero_realtime(
     family = model.config.backbone_family
     liger_fn = family_liger_fn(family)
 
+    # qwen3_5 / qwen3_5_moe use hybrid attention (Gated DeltaNet + Gated
+    # Attention), incompatible with liger_rotary_pos_emb — force rope off
+    # for these families.
+    if family in ("qwen3_5", "qwen3_5_moe"):
+        rope = False
+
     # 1. Patch language sub-model
     liger_fn(
         model=model.language_model,

--- a/src/lmms_engine/models/aero_realtime/processing_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/processing_aero_realtime.py
@@ -103,6 +103,7 @@ class AeroRealtimeProcessor(ProcessorMixin):
     valid_kwargs = [
         "chat_template",
         "downsample_factor",
+        "audio_length_per_tok",
         "image_token",
         "video_token",
         "audio_token",
@@ -128,6 +129,7 @@ class AeroRealtimeProcessor(ProcessorMixin):
         tokenizer=None,
         chat_template=None,
         downsample_factor: int = 4,
+        audio_length_per_tok: int = 8,
         image_token: str = "<|image_pad|>",
         video_token: str = "<|video_pad|>",
         audio_token: str = "<|audio_pad|>",
@@ -171,6 +173,7 @@ class AeroRealtimeProcessor(ProcessorMixin):
 
         # Model config parameters needed for timestep computation
         self.downsample_factor = downsample_factor
+        self.audio_length_per_tok = audio_length_per_tok
 
         if chat_template is None:
             chat_template = self.default_chat_template
@@ -285,7 +288,7 @@ class AeroRealtimeProcessor(ProcessorMixin):
                 audio,
                 sampling_rate=sampling_rate,
                 return_attention_mask=True,
-                padding="max_length",
+                padding="longest",
                 **fe_kwargs,
             )
             # Rename keys to avoid conflicts with text attention_mask
@@ -309,10 +312,18 @@ class AeroRealtimeProcessor(ProcessorMixin):
             has_video = video_grid_thw is not None
             has_audio = bool(audio_inputs)
 
-            # Pre-compute audio token counts per sample (mel-frame-derived)
+            # Pre-compute audio token counts per sample (mel-frame-derived).
+            # ``feature_extractor.attention_mask`` lags ``input_features`` by
+            # a small constant (reflection-pad frames at the mel boundary),
+            # so we add ``pad_offset`` to each sample's mel length before the
+            # ceil-div, matching what the post-conv2 mask emission does at
+            # the end of ``__call__``.
             num_audio_tokens_list = None
             if has_audio:
-                mel_lengths = audio_inputs["audio_attention_mask"].sum(-1)
+                mel_mask = audio_inputs["audio_attention_mask"]
+                T_mel = audio_inputs["input_features"].shape[-1]
+                pad_offset = T_mel - mel_mask.shape[-1]
+                mel_lengths = mel_mask.sum(-1).to(torch.long) + pad_offset
                 num_audio_tokens_list = [self._get_num_audio_tokens(int(m.item())) for m in mel_lengths]
 
             # 5b. Video + Audio -> separated per-chunk vision/audio envelopes
@@ -462,6 +473,46 @@ class AeroRealtimeProcessor(ProcessorMixin):
         # ==============================================================
         # 8. Assemble output
         # ==============================================================
+        # Convert audio_attention_mask from mel-level (T_mel) to
+        # post-conv2 encoder length (T_enc = T_mel // 2) —
+        # this is what VoxtralRealtimeEncoder.forward expects as
+        # ``attention_mask``. Internal helpers above operated on the
+        # mel-level mask; downstream model code consumes the encoder-level mask.
+        if audio_inputs and "audio_attention_mask" in audio_inputs:
+            mel_mask = audio_inputs["audio_attention_mask"]
+            if not isinstance(mel_mask, torch.Tensor):
+                mel_mask = torch.as_tensor(mel_mask)
+            # Canonical T_mel comes from the mel feature tensor itself, not
+            # the FE attention_mask (which may be sample-grid-aligned and a
+            # few frames shorter than input_features due to reflection
+            # padding inside the FE).
+            input_features = audio_inputs.get("input_features", None)
+            if input_features is None:
+                T_mel = mel_mask.shape[-1]
+            else:
+                if not isinstance(input_features, torch.Tensor):
+                    input_features = torch.as_tensor(input_features)
+                T_mel = input_features.shape[-1]
+            mel_mask_len = mel_mask.shape[-1]
+            # Per-sample valid frame count in the mel feature. Add the
+            # constant pad offset (T_mel - mel_mask_len) to map valid
+            # FE-mask frames onto the mel grid.
+            pad_offset = max(0, T_mel - mel_mask_len)
+            mel_lengths_t = mel_mask.sum(-1).to(torch.long) + pad_offset
+            B = mel_mask.shape[0]
+            # Voxtral conv2: kernel=3, stride=2, left_pad=1 →
+            #   T_enc = (T_mel + left_pad - kernel) / stride + 1 = T_mel // 2
+            T_enc = T_mel // 2
+            enc_mask = torch.zeros(B, T_enc, dtype=torch.long)
+            for i in range(B):
+                m = int(mel_lengths_t[i].item())
+                # Clamp to T_mel (a sample's valid mel can't exceed full grid)
+                m = min(m, T_mel)
+                enc_m = m // 2 if m > 0 else 0
+                if enc_m > 0:
+                    enc_mask[i, :enc_m] = 1
+            audio_inputs["audio_attention_mask"] = enc_mask
+
         return BatchFeature(
             data={
                 **text_inputs,
@@ -540,22 +591,17 @@ class AeroRealtimeProcessor(ProcessorMixin):
         return counts
 
     def _get_num_audio_tokens(self, mel_frames: int) -> int:
-        """Compute the number of projected audio tokens from mel frame count.
+        """LM audio token count for a given mel-frame count.
 
-        Applies the audio encoder's internal downsampling (conv2 stride=2 +
-        avg_pool stride=2 for Qwen2Audio) and then the projector's
-        ``downsample_factor``.
-
-        Args:
-            mel_frames: Number of mel spectrogram frames (after feature
-                extraction, before audio encoder).
-
-        Returns:
-            Number of audio tokens after full downsampling + projection.
+        Voxtral encoder pipeline:
+          - conv2 (kernel=3, stride=2, left_pad=1): mel → ``T_enc = mel // 2``
+          - downsample_factor concat: ``T_enc // df`` LM tokens
+        Combined: ``mel // (2 * df) = mel // audio_length_per_tok``.
+        With ``audio_length_per_tok = 8`` this is 80ms per LM token.
+        Uses floor (not ceil) to match the modeling-side truncation
+        ``usable_len = (T_enc // df) * df``.
         """
-        encoder_tokens = self._get_audio_encoder_output_length(mel_frames)
-        projected_tokens = encoder_tokens // self.downsample_factor
-        return projected_tokens
+        return mel_frames // self.audio_length_per_tok
 
     @staticmethod
     def _get_audio_encoder_output_length(mel_frames: int) -> int:

--- a/src/lmms_engine/models/aero_realtime/processing_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/processing_aero_realtime.py
@@ -1,0 +1,840 @@
+# coding=utf-8
+# Copyright 2025 LMMs-Lab team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AeroRealtime processor.
+
+Handles preprocessing of audio, image/video, and text inputs before they
+are passed to the AeroRealtime model.  Builds per-chunk audio-vision
+envelopes and the realtime ``text_stream_ids`` used by the dual-stream
+decoder.
+"""
+
+from typing import List, Optional, Union
+
+import numpy as np
+import torch
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.image_utils import ImageInput
+from transformers.processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
+from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
+from transformers.utils import logging
+from transformers.video_utils import VideoInput
+
+logger = logging.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Kwargs defaults
+# ---------------------------------------------------------------------------
+
+
+class AeroRealtimeProcessorKwargs(ProcessingKwargs, total=False):
+    _defaults = {
+        "text_kwargs": {
+            "padding": False,
+            "return_token_type_ids": False,
+        },
+        "audio_kwargs": {},
+        "videos_kwargs": {
+            "return_metadata": True,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Processor
+# ---------------------------------------------------------------------------
+
+
+class AeroRealtimeProcessor(ProcessorMixin):
+    r"""Processor for the AeroRealtime model.
+
+    Combines an image processor (for images), a video processor (for video),
+    a feature extractor (for audio), and a tokenizer into a single
+    processor.
+
+    The processor handles:
+    - Image preprocessing via ``image_processor`` (e.g. ``Qwen2VLImageProcessor``).
+    - Video preprocessing via ``video_processor`` (e.g. ``Qwen3VLVideoProcessor``).
+      Supports both video file paths (loaded automatically) and pre-extracted
+      frames (requires ``video_metadata`` with fps and frame indices).
+    - Audio preprocessing via ``feature_extractor`` (e.g. ``WhisperFeatureExtractor``).
+    - Text tokenization with placeholder expansion for images, videos, and
+      audio tokens.
+    - Construction of ``text_stream_ids`` carrying realtime context markers
+      on audio positions when audio is present (streaming mode).
+
+    Args:
+        image_processor: Image processor instance (e.g. ``Qwen2VLImageProcessor``).
+        video_processor: Video processor instance (e.g. ``Qwen3VLVideoProcessor``).
+        feature_extractor: Audio feature extractor instance
+            (e.g. ``WhisperFeatureExtractor`` with ``feature_size=128``).
+        tokenizer: Text tokenizer instance.
+        chat_template (`str`, *optional*): Jinja chat template.
+        downsample_factor (`int`, *optional*, defaults to ``4``):
+            Audio projector downsampling factor.  After the audio encoder,
+            ``downsample_factor`` consecutive encoder tokens are concatenated
+            before projection.
+        image_token (`str`, *optional*, defaults to ``"<|image_pad|>"``):
+            Placeholder token for image features.
+        video_token (`str`, *optional*, defaults to ``"<|video_pad|>"``):
+            Placeholder token for video features.
+        audio_token (`str`, *optional*, defaults to ``"<|audio_pad|>"``):
+            Placeholder token for audio features.
+        vision_start_token (`str`, *optional*, defaults to ``"<|vision_start|>"``):
+            Token marking the start of a vision segment.
+        vision_end_token (`str`, *optional*, defaults to ``"<|vision_end|>"``):
+            Token marking the end of a vision segment.
+    """
+
+    attributes = ["image_processor", "video_processor", "feature_extractor", "tokenizer"]
+    valid_kwargs = [
+        "chat_template",
+        "downsample_factor",
+        "image_token",
+        "video_token",
+        "audio_token",
+        "vision_start_token",
+        "vision_end_token",
+        "audio_start_token",
+        "audio_end_token",
+        "rt_start_token",
+        "rt_pad_token",
+        "rt_speak_token",
+        "rt_end_token",
+    ]
+    image_processor_class = "AutoImageProcessor"
+    video_processor_class = "AutoVideoProcessor"
+    feature_extractor_class = "AutoFeatureExtractor"
+    tokenizer_class = "AutoTokenizer"
+
+    def __init__(
+        self,
+        image_processor=None,
+        video_processor=None,
+        feature_extractor=None,
+        tokenizer=None,
+        chat_template=None,
+        downsample_factor: int = 4,
+        image_token: str = "<|image_pad|>",
+        video_token: str = "<|video_pad|>",
+        audio_token: str = "<|audio_pad|>",
+        vision_start_token: str = "<|vision_start|>",
+        vision_end_token: str = "<|vision_end|>",
+        audio_start_token: str = "<|audio_start|>",
+        audio_end_token: str = "<|audio_end|>",
+        rt_start_token: str = "<|rt_start|>",
+        rt_pad_token: str = "<|rt_pad|>",
+        rt_speak_token: str = "<|rt_speak|>",
+        rt_end_token: str = "<|rt_end|>",
+        **kwargs,
+    ):
+        # Resolve tokens from tokenizer if available, otherwise use defaults
+        self.image_token = getattr(tokenizer, "image_token", image_token) if tokenizer else image_token
+        self.video_token = getattr(tokenizer, "video_token", video_token) if tokenizer else video_token
+        self.audio_token = getattr(tokenizer, "audio_token", audio_token) if tokenizer else audio_token
+        self.vision_start_token = (
+            getattr(tokenizer, "vision_start_token", vision_start_token) if tokenizer else vision_start_token
+        )
+        self.vision_end_token = (
+            getattr(tokenizer, "vision_end_token", vision_end_token) if tokenizer else vision_end_token
+        )
+        self.audio_start_token = (
+            getattr(tokenizer, "audio_start_token", audio_start_token) if tokenizer else audio_start_token
+        )
+        self.audio_end_token = getattr(tokenizer, "audio_end_token", audio_end_token) if tokenizer else audio_end_token
+        self.rt_start_token = rt_start_token
+        self.rt_pad_token = rt_pad_token
+        self.rt_speak_token = rt_speak_token
+        self.rt_end_token = rt_end_token
+
+        # Token IDs needed by _expand_encode_id_video_tokens (inherited from Qwen3VL)
+        if tokenizer is not None:
+            self.vision_start_token_id = tokenizer.convert_tokens_to_ids(self.vision_start_token)
+            self.vision_end_token_id = tokenizer.convert_tokens_to_ids(self.vision_end_token)
+            self.audio_start_token_id = tokenizer.convert_tokens_to_ids(self.audio_start_token)
+            self.audio_end_token_id = tokenizer.convert_tokens_to_ids(self.audio_end_token)
+            self.audio_token_id = tokenizer.convert_tokens_to_ids(self.audio_token)
+            self.video_token_id = tokenizer.convert_tokens_to_ids(self.video_token)
+
+        # Model config parameters needed for timestep computation
+        self.downsample_factor = downsample_factor
+
+        if chat_template is None:
+            chat_template = self.default_chat_template
+
+        super().__init__(
+            image_processor,
+            video_processor,
+            feature_extractor,
+            tokenizer,
+            chat_template=chat_template,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # Main __call__
+    # ------------------------------------------------------------------
+
+    def __call__(
+        self,
+        text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]] = None,
+        images: ImageInput = None,
+        videos: VideoInput = None,
+        audio: Union[np.ndarray, List[np.ndarray]] = None,
+        video_metadata: Optional[list] = None,
+        sampling_rate: Optional[int] = None,
+        **kwargs: Unpack[AeroRealtimeProcessorKwargs],
+    ) -> BatchFeature:
+        """Preprocess multimodal inputs for the AeroRealtime model.
+
+        Accepts any combination of text, images, videos, and audio.  When
+        both video and audio are provided the processor emits per-chunk
+        ``[VS][video_pad×S][VE][AS][audio_pad×N][AE]`` envelopes so that
+        time alignment is expressed through token order and RoPE.
+
+        Args:
+            text: One or a batch of text strings (may contain placeholder
+                tokens for image / video / audio).
+            images: One or more images (PIL, ndarray, or tensor).
+            videos: One or more videos.  Each element can be:
+                - A file path (``str``) -- the video processor will load
+                  and sample frames automatically.
+                - A tensor / ndarray of pre-extracted frames -- in this
+                  case ``video_metadata`` **must** be provided with at
+                  least ``fps`` and ``frames_indices`` for each video.
+            audio: One or more raw audio waveforms (mono, float32, 16 kHz).
+            video_metadata: List of ``VideoMetadata`` (or dicts with
+                ``fps`` and ``frames_indices``).  Required when ``videos``
+                are pre-extracted frames; auto-populated when ``videos``
+                are file paths.
+            sampling_rate: Audio sampling rate.  If ``None``, uses the
+                feature extractor's default (typically 16 000 Hz).
+
+        Returns:
+            :class:`~transformers.BatchFeature` with the following fields
+            (present only when the corresponding input is given):
+
+            - ``input_ids``, ``attention_mask`` -- tokenised text.
+            - ``pixel_values``, ``image_grid_thw`` -- image features.
+            - ``pixel_values_videos``, ``video_grid_thw`` -- video features.
+            - ``input_features`` -- audio mel spectrogram.
+            - ``audio_attention_mask`` -- audio attention mask (mel-level).
+            - ``text_stream_ids`` -- realtime text-stream tokens (only when
+              audio is present).
+        """
+        output_kwargs = self._merge_kwargs(
+            AeroRealtimeProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+
+        # ==============================================================
+        # 1. Normalise text to list
+        # ==============================================================
+        if text is not None:
+            if isinstance(text, str):
+                text = [text]
+            text = list(text)  # copy so we can mutate
+
+        # ==============================================================
+        # 2. Process images
+        # ==============================================================
+        image_inputs = {}
+        image_grid_thw = None
+        if images is not None:
+            image_inputs = self.image_processor(images=images, **output_kwargs.get("images_kwargs", {}))
+            image_grid_thw = image_inputs["image_grid_thw"]
+
+        # ==============================================================
+        # 3. Process videos
+        # ==============================================================
+        video_inputs = {}
+        video_grid_thw = None
+        _video_metadata = None
+        if videos is not None:
+            videos_kwargs = output_kwargs.get("videos_kwargs", {})
+            # Always request metadata internally (needed for timesteps)
+            videos_kwargs["return_metadata"] = True
+            if video_metadata is not None:
+                videos_kwargs["video_metadata"] = video_metadata
+
+            video_inputs = self.video_processor(videos=videos, **videos_kwargs)
+            video_grid_thw = video_inputs["video_grid_thw"]
+            _video_metadata = video_inputs.pop("video_metadata")
+
+        # ==============================================================
+        # 4. Process audio
+        # ==============================================================
+        audio_inputs = {}
+        if audio is not None:
+            fe_kwargs = output_kwargs.get("audio_kwargs", {})
+            audio_inputs = self.feature_extractor(
+                audio,
+                sampling_rate=sampling_rate,
+                return_attention_mask=True,
+                padding="max_length",
+                **fe_kwargs,
+            )
+            # Rename keys to avoid conflicts with text attention_mask
+            audio_inputs["audio_attention_mask"] = audio_inputs.pop("attention_mask")
+
+        # ==============================================================
+        # 5. Expand placeholder tokens in text
+        # ==============================================================
+        if text is not None:
+            # 5a. Image placeholders
+            if image_grid_thw is not None:
+                merge_length = self.image_processor.merge_size**2
+                idx = 0
+                for i in range(len(text)):
+                    while self.image_token in text[i]:
+                        num_tokens = int(image_grid_thw[idx].prod() // merge_length)
+                        text[i] = text[i].replace(self.image_token, "<|placeholder|>" * num_tokens, 1)
+                        idx += 1
+                    text[i] = text[i].replace("<|placeholder|>", self.image_token)
+
+            has_video = video_grid_thw is not None
+            has_audio = bool(audio_inputs)
+
+            # Pre-compute audio token counts per sample (mel-frame-derived)
+            num_audio_tokens_list = None
+            if has_audio:
+                mel_lengths = audio_inputs["audio_attention_mask"].sum(-1)
+                num_audio_tokens_list = [self._get_num_audio_tokens(int(m.item())) for m in mel_lengths]
+
+            # 5b. Video + Audio -> separated per-chunk vision/audio envelopes
+            #
+            #   <t.t seconds><|vision_start|><|video_pad|>×spatial<|vision_end|>
+            #   <|audio_start|><|audio_pad|>×N_t<|audio_end|>
+            #
+            # One envelope per video temporal grid (each grid covers
+            # ``second_per_grid = temporal_patch_size / fps`` seconds of
+            # video).  Audio tokens are split across grids by a two-pointer
+            # merge on the actual audio time axis: audio token ``a`` lives
+            # at time ``a / audio_rate`` (seconds), and is placed in the
+            # first grid whose end time is greater than ``a``'s time.
+            if video_grid_thw is not None and has_audio:
+                merge_length = self.video_processor.merge_size**2
+                temporal_patch_size = getattr(self.video_processor, "temporal_patch_size", 2)
+                v_idx = 0
+                a_sample_idx = 0
+                for i in range(len(text)):
+                    while self.video_token in text[i]:
+                        metadata = _video_metadata[v_idx]
+                        if metadata.fps is None:
+                            metadata.fps = 24.0
+                        grid_t = int(video_grid_thw[v_idx][0])
+                        spatial = int(video_grid_thw[v_idx][1:].prod() // merge_length)
+                        curr_timestamp = self._calculate_timestamps(
+                            metadata.frames_indices,
+                            metadata.fps,
+                            temporal_patch_size,
+                        )
+
+                        # Audio for this video sample
+                        n_audio = num_audio_tokens_list[a_sample_idx]
+                        audio_duration = self._get_audio_duration_seconds(
+                            audio_inputs["audio_attention_mask"][a_sample_idx]
+                        )
+                        # Tokens-per-second for this audio (avoid div-by-zero)
+                        audio_rate = (n_audio / audio_duration) if audio_duration > 0 else 0.0
+
+                        # Distribute audio by the actual sampled video chunk timestamps.
+                        audio_per_chunk = self._split_audio_across_chunk_times(
+                            n_audio=n_audio,
+                            chunk_start_times=curr_timestamp[:grid_t],
+                            audio_rate=audio_rate,
+                        )
+
+                        chunk_strs = []
+                        for t in range(grid_t):
+                            t_sec = curr_timestamp[t] if t < len(curr_timestamp) else curr_timestamp[-1]
+                            chunk_strs.append(
+                                f"<{t_sec:.1f} seconds>"
+                                f"{self.vision_start_token}"
+                                f"{'<|videopad|>' * spatial}"
+                                f"{self.vision_end_token}"
+                                f"{self.audio_start_token}"
+                                f"{'<|audiopad|>' * audio_per_chunk[t]}"
+                                f"{self.audio_end_token}"
+                            )
+                        replacement = "".join(chunk_strs)
+
+                        wrapped = f"{self.vision_start_token}{self.video_token}{self.vision_end_token}"
+                        if wrapped in text[i]:
+                            text[i] = text[i].replace(wrapped, replacement, 1)
+                        else:
+                            text[i] = text[i].replace(self.video_token, replacement, 1)
+                        v_idx += 1
+                        a_sample_idx += 1
+                    text[i] = text[i].replace("<|videopad|>", self.video_token)
+                    text[i] = text[i].replace("<|audiopad|>", self.audio_token)
+
+            # 5c. Video-only -> per-frame VS/VE + timestamp text (legacy Qwen3VL style)
+            elif video_grid_thw is not None:
+                merge_length = self.video_processor.merge_size**2
+                idx = 0
+                for i in range(len(text)):
+                    while self.video_token in text[i]:
+                        metadata = _video_metadata[idx]
+                        if metadata.fps is None:
+                            logger.warning_once(
+                                "Frame timestamps are required to construct prompts, but the `fps` of the input video "
+                                "could not be inferred. Probably `video_metadata` was missing from inputs and you "
+                                "passed pre-sampled frames. Defaulting to `fps=24`. Please provide `video_metadata` "
+                                "for more accurate results."
+                            )
+                            metadata.fps = 24.0
+
+                        curr_timestamp = self._calculate_timestamps(
+                            metadata.frames_indices,
+                            metadata.fps,
+                            getattr(self.video_processor, "temporal_patch_size", 2),
+                        )
+
+                        video_placeholder = ""
+                        frame_seqlen = int(video_grid_thw[idx][1:].prod() // merge_length)
+                        for frame_idx in range(int(video_grid_thw[idx][0])):
+                            curr_time = curr_timestamp[frame_idx]
+                            video_placeholder += f"<{curr_time:.1f} seconds>"
+                            video_placeholder += (
+                                self.vision_start_token + "<|videopad|>" * frame_seqlen + self.vision_end_token
+                            )
+
+                        wrapped = f"{self.vision_start_token}{self.video_token}{self.vision_end_token}"
+                        if wrapped in text[i]:
+                            text[i] = text[i].replace(wrapped, video_placeholder, 1)
+                        else:
+                            text[i] = text[i].replace(self.video_token, video_placeholder, 1)
+                        idx += 1
+                    text[i] = text[i].replace("<|videopad|>", self.video_token)
+
+            # 5d. Audio-only -> single envelope <|audio_start|><|audio_pad|>×N<|audio_end|>
+            if has_audio and not has_video:
+                idx = 0
+                for i in range(len(text)):
+                    while self.audio_token in text[i]:
+                        n_tok = num_audio_tokens_list[idx]
+                        replacement = f"{self.audio_start_token}" f"{'<|audiopad|>' * n_tok}" f"{self.audio_end_token}"
+                        text[i] = text[i].replace(self.audio_token, replacement, 1)
+                        idx += 1
+                    text[i] = text[i].replace("<|audiopad|>", self.audio_token)
+
+        # ==============================================================
+        # 6. Tokenize text
+        # ==============================================================
+        text_inputs = {}
+        if text is not None:
+            return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
+            text_inputs = self.tokenizer(text, **output_kwargs["text_kwargs"])
+        else:
+            return_tensors = None
+
+        # ==============================================================
+        # 7. Build text_stream_ids — only in streaming mode (audio present)
+        # ==============================================================
+        has_video = video_grid_thw is not None
+        text_stream_outputs = {}
+        if text_inputs and audio_inputs:
+            input_ids = text_inputs["input_ids"]
+            text_stream_ids = self._build_text_stream_ids(
+                input_ids=input_ids,
+                video_grid_thw=video_grid_thw,
+                video_metadata=_video_metadata,
+                audio_attention_mask=audio_inputs.get("audio_attention_mask", None),
+                has_video=has_video,
+            )
+            text_stream_outputs["text_stream_ids"] = text_stream_ids
+
+        # ==============================================================
+        # 8. Assemble output
+        # ==============================================================
+        return BatchFeature(
+            data={
+                **text_inputs,
+                **image_inputs,
+                **video_inputs,
+                **audio_inputs,
+                **text_stream_outputs,
+            },
+            tensor_type=return_tensors,
+        )
+
+    # ------------------------------------------------------------------
+    # Audio helpers
+    # ------------------------------------------------------------------
+
+    def _get_audio_duration_seconds(self, audio_attention_mask_row: torch.Tensor) -> float:
+        """Return the wall-clock duration (seconds) of one audio sample."""
+        hop_length = getattr(self.feature_extractor, "hop_length", 160)
+        sampling_rate = getattr(self.feature_extractor, "sampling_rate", 16000)
+        mel_len = int(audio_attention_mask_row.sum().item())
+        return mel_len * hop_length / sampling_rate
+
+    @staticmethod
+    def _split_audio_across_chunks(
+        n_audio: int,
+        grid_t: int,
+        second_per_grid: float,
+        audio_rate: float,
+    ) -> List[int]:
+        """Distribute ``n_audio`` audio tokens across ``grid_t`` video chunks
+        by their wall-clock time.
+
+        Audio token ``a`` lives at time ``a / audio_rate`` (seconds).  It is
+        assigned to the first chunk ``t`` whose end time
+        ``(t + 1) * second_per_grid`` is greater than ``a``'s time.  Audio
+        tokens past the last chunk's end time are appended to the last chunk.
+
+        Returns a list of length ``grid_t`` whose sum equals ``n_audio``.
+        """
+        if grid_t <= 0:
+            return []
+        if n_audio <= 0 or audio_rate <= 0:
+            counts = [0] * grid_t
+            return counts
+
+        counts = [0] * grid_t
+        for a in range(n_audio):
+            t_sec = a / audio_rate
+            chunk_idx = int(t_sec // second_per_grid)
+            if chunk_idx >= grid_t:
+                chunk_idx = grid_t - 1
+            counts[chunk_idx] += 1
+        return counts
+
+    @staticmethod
+    def _split_audio_across_chunk_times(
+        n_audio: int,
+        chunk_start_times: List[float],
+        audio_rate: float,
+    ) -> List[int]:
+        """Distribute audio tokens using actual video chunk start times."""
+        grid_t = len(chunk_start_times)
+        if grid_t <= 0:
+            return []
+        if n_audio <= 0 or audio_rate <= 0:
+            return [0] * grid_t
+
+        counts = [0] * grid_t
+        boundaries = chunk_start_times[1:]
+        for a in range(n_audio):
+            t_sec = a / audio_rate
+            chunk_idx = 0
+            while chunk_idx < len(boundaries) and t_sec >= boundaries[chunk_idx]:
+                chunk_idx += 1
+            counts[chunk_idx] += 1
+        return counts
+
+    def _get_num_audio_tokens(self, mel_frames: int) -> int:
+        """Compute the number of projected audio tokens from mel frame count.
+
+        Applies the audio encoder's internal downsampling (conv2 stride=2 +
+        avg_pool stride=2 for Qwen2Audio) and then the projector's
+        ``downsample_factor``.
+
+        Args:
+            mel_frames: Number of mel spectrogram frames (after feature
+                extraction, before audio encoder).
+
+        Returns:
+            Number of audio tokens after full downsampling + projection.
+        """
+        encoder_tokens = self._get_audio_encoder_output_length(mel_frames)
+        projected_tokens = encoder_tokens // self.downsample_factor
+        return projected_tokens
+
+    @staticmethod
+    def _get_audio_encoder_output_length(mel_frames: int) -> int:
+        """Compute audio encoder output length from mel spectrogram length.
+
+        Default implementation matches the Qwen2Audio encoder architecture:
+        ``conv2`` with stride=2 followed by ``avg_pool`` with stride=2.
+
+        Override this method if using a different audio encoder.
+
+        Args:
+            mel_frames: Number of mel spectrogram frames.
+
+        Returns:
+            Number of encoder output tokens.
+        """
+        after_conv2 = (mel_frames - 1) // 2 + 1
+        after_avg_pool = (after_conv2 - 2) // 2 + 1
+        return after_avg_pool
+
+    @staticmethod
+    def _calculate_timestamps(
+        frames_indices: Union[list, np.ndarray],
+        fps: float,
+        temporal_patch_size: int = 2,
+    ) -> list:
+        """Compute per-temporal-patch timestamps from sampled frame indices.
+
+        Groups ``temporal_patch_size`` consecutive frames and returns the
+        average timestamp (in seconds) for each group.  Follows the same
+        logic as ``Qwen3VLProcessor._calculate_timestamps``.
+
+        Args:
+            frames_indices: Indices of sampled frames in the original video.
+            fps: Native FPS of the video.
+            temporal_patch_size: Number of frames merged into one temporal
+                patch (default ``2``).
+
+        Returns:
+            List of timestamps in seconds, one per temporal patch.
+        """
+        if not isinstance(frames_indices, list):
+            frames_indices = list(frames_indices)
+
+        # Pad to be divisible by temporal_patch_size
+        if len(frames_indices) % temporal_patch_size != 0:
+            pad_count = temporal_patch_size - len(frames_indices) % temporal_patch_size
+            frames_indices.extend([frames_indices[-1]] * pad_count)
+
+        # Convert frame indices to seconds
+        timestamps_sec = [idx / fps for idx in frames_indices]
+
+        # Average consecutive groups
+        grouped = []
+        for i in range(0, len(timestamps_sec), temporal_patch_size):
+            group = timestamps_sec[i : i + temporal_patch_size]
+            grouped.append(sum(group) / len(group))
+
+        return grouped
+
+    # ------------------------------------------------------------------
+    # Text stream construction
+    # ------------------------------------------------------------------
+
+    def _build_text_stream_ids(
+        self,
+        input_ids: Union[list, torch.Tensor],
+        video_grid_thw: Optional[torch.LongTensor] = None,
+        video_metadata: Optional[list] = None,
+        audio_attention_mask: Optional[torch.Tensor] = None,
+        has_video: bool = False,
+    ) -> Union[list, torch.Tensor]:
+        """Build ``text_stream_ids`` for the realtime dual-stream design.
+
+        ``text_stream_ids`` mirrors ``input_ids`` everywhere except audio
+        placeholder positions, where it carries realtime context tokens.
+
+        Streaming mode is gated on the presence of audio.  Two layouts:
+
+        - **video + audio (interleave)**: input contains per-chunk envelopes
+          ``[VS][video_pad×S][VE][AS][audio_pad×N][AE]``.  Video placeholders
+          stay as ``<|video_pad|>``; audio placeholders default to
+          ``<|rt_pad|>`` and may carry teacher-forced speech tokens.
+        - **audio-only**: ``[AS][audio_pad×N][AE]``. First ``audio_pad``
+          becomes ``<|rt_speak|>`` (the model decides when to start
+          speaking); the rest are ``<|rt_pad|>``.
+        """
+        is_tensor = isinstance(input_ids, torch.Tensor)
+        if is_tensor:
+            input_ids_list = input_ids.tolist()
+        else:
+            input_ids_list = [list(ids) for ids in input_ids]
+
+        rt_pad_id = self.tokenizer.convert_tokens_to_ids(self.rt_pad_token)
+        audio_start_id = self.tokenizer.convert_tokens_to_ids(self.audio_start_token)
+        audio_end_id = self.tokenizer.convert_tokens_to_ids(self.audio_end_token)
+
+        has_audio = audio_attention_mask is not None and audio_attention_mask.numel() > 0
+        temporal_patch_size = getattr(self.video_processor, "temporal_patch_size", 2)
+
+        result = []
+        for batch_idx, ids in enumerate(input_ids_list):
+            stream = list(ids)
+
+            if has_video and has_audio:
+                # --- video + audio interleave ---
+                self._fill_text_stream_video_audio(
+                    stream=stream,
+                    video_grid_thw=video_grid_thw,
+                    video_metadata=video_metadata,
+                    temporal_patch_size=temporal_patch_size,
+                    audio_start_id=audio_start_id,
+                    audio_end_id=audio_end_id,
+                    rt_pad_id=rt_pad_id,
+                )
+            elif has_audio:
+                # --- audio-only envelope ---
+                self._fill_text_stream_audio_only(
+                    stream=stream,
+                    sample_idx=batch_idx,
+                    audio_start_id=audio_start_id,
+                    audio_end_id=audio_end_id,
+                    rt_pad_id=rt_pad_id,
+                )
+
+            result.append(stream)
+
+        if is_tensor:
+            return torch.tensor(result, dtype=input_ids.dtype, device=input_ids.device)
+        return result
+
+    # ------------------------------------------------------------------
+    # text_stream fillers (one per mode)
+    # ------------------------------------------------------------------
+
+    def _fill_text_stream_video_audio(
+        self,
+        stream: list,
+        video_grid_thw,
+        video_metadata,
+        temporal_patch_size: int,
+        audio_start_id: int,
+        audio_end_id: int,
+        rt_pad_id: int,
+    ) -> None:
+        """In-place fill of text_stream for separated video+audio envelopes.
+
+        Only ``<|audio_pad|>`` positions are overwritten with ``<|rt_pad|>``.
+        Boundary and speech teacher forcing is applied by the data processor.
+
+        ``<|video_pad|>`` positions keep their original ids because video
+        features replace those embeddings in the model.
+
+        Envelope boundary tokens (``<t.t seconds>``, ``<|vision_start|>``,
+        ``<|vision_end|>``, ``<|audio_start|>``, ``<|audio_end|>``) keep
+        their original ids so the LM sees the same special tokens it would
+        in input_ids.
+        """
+        ids_t = torch.tensor(stream)
+        as_idx = (ids_t == audio_start_id).nonzero(as_tuple=True)[0].tolist()
+        ae_idx = (ids_t == audio_end_id).nonzero(as_tuple=True)[0].tolist()
+
+        audio_envelopes = list(zip(as_idx, ae_idx))
+        if not audio_envelopes:
+            return
+
+        # Flatten per-chunk metadata: (v_idx, t_in_video, t_sec, spatial)
+        merge_length = self.video_processor.merge_size**2
+        chunks = []
+        for v_idx in range(len(video_grid_thw)):
+            metadata = video_metadata[v_idx]
+            fps = metadata.fps if metadata.fps is not None else 24.0
+            grid_t = int(video_grid_thw[v_idx][0])
+            spatial = int(video_grid_thw[v_idx][1:].prod() // merge_length)
+            curr_timestamp = self._calculate_timestamps(
+                metadata.frames_indices,
+                fps,
+                temporal_patch_size,
+            )
+            for t in range(grid_t):
+                t_sec = curr_timestamp[t] if t < len(curr_timestamp) else curr_timestamp[-1]
+                chunks.append((v_idx, t, t_sec, spatial))
+
+        if len(chunks) != len(audio_envelopes):
+            raise ValueError(
+                f"Chunk count mismatch: {len(chunks)} expected audio envelopes from "
+                f"video_grid_thw, found {len(audio_envelopes)} in tokenized stream."
+            )
+
+        for as_, ae in audio_envelopes:
+            # Envelope layout (token positions):
+            #   as_:          <|audio_start|>
+            #   as_+1 .. ae-1:<|audio_pad|> × N_t
+            #   ae:           <|audio_end|>
+            audio_pad_start = as_ + 1
+            audio_pad_end = ae - 1  # inclusive
+
+            for k in range(audio_pad_start, audio_pad_end + 1):
+                stream[k] = rt_pad_id
+
+    def _fill_text_stream_audio_only(
+        self,
+        stream: list,
+        sample_idx: int,
+        audio_start_id: int,
+        audio_end_id: int,
+        rt_pad_id: int,
+    ) -> None:
+        """Audio-only envelope text_stream filler.
+
+        Layout produced by the processor: ``[AS][audio_pad×N][AE]``.
+
+        Every audio_pad position defaults to ``rt_pad`` (silence). The dataset
+        processor overrides positions occupied by speech tokens at training
+        time; at inference the model is free to emit text content from any
+        audio_pad position.
+        """
+        ids_t = torch.tensor(stream)
+        as_positions = (ids_t == audio_start_id).nonzero(as_tuple=True)[0].tolist()
+        ae_positions = (ids_t == audio_end_id).nonzero(as_tuple=True)[0].tolist()
+        if sample_idx >= len(as_positions) or sample_idx >= len(ae_positions):
+            return
+        as_pos = as_positions[sample_idx]
+        ae_pos = ae_positions[sample_idx]
+        if ae_pos - as_pos - 1 <= 0:
+            return
+        for k in range(as_pos + 1, ae_pos):
+            stream[k] = rt_pad_id
+
+    # ------------------------------------------------------------------
+    # Decode helpers
+    # ------------------------------------------------------------------
+
+    def batch_decode(self, *args, **kwargs):
+        """Decode a batch of token ids to strings."""
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        """Decode token ids to a string."""
+        return self.tokenizer.decode(*args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Default chat template
+    # ------------------------------------------------------------------
+
+    @property
+    def default_chat_template(self):
+        # fmt: off
+        return (
+            "{% set audio_count = namespace(value=0) %}"
+            "{% set image_count = namespace(value=0) %}"
+            "{% set video_count = namespace(value=0) %}"
+            "{% for message in messages %}"
+                "{% if loop.first and message['role'] != 'system' %}"
+                    "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
+                "{% endif %}"
+                "<|im_start|>{{ message['role'] }}\n"
+                "{% if message['content'] is string %}"
+                    "{{ message['content'] }}<|im_end|>\n"
+                "{% else %}"
+                    "{% for content in message['content'] %}"
+                        "{% if 'audio' in content or 'audio_url' in content %}"
+                            "{% set audio_count.value = audio_count.value + 1 %}"
+                            "<|audio_pad|>"
+                        "{% elif 'image' in content or 'image_url' in content %}"
+                            "{% set image_count.value = image_count.value + 1 %}"
+                            "<|vision_start|><|image_pad|><|vision_end|>"
+                        "{% elif 'video' in content or 'video_url' in content %}"
+                            "{% set video_count.value = video_count.value + 1 %}"
+                            "<|vision_start|><|video_pad|><|vision_end|>"
+                        "{% elif 'text' in content %}"
+                            "{{ content['text'] }}"
+                        "{% endif %}"
+                    "{% endfor %}"
+                    "<|im_end|>\n"
+                "{% endif %}"
+            "{% endfor %}"
+            "{% if add_generation_prompt %}"
+                "<|im_start|>assistant\n"
+            "{% endif %}"
+        )
+        # fmt: on

--- a/src/lmms_engine/models/aero_realtime/processing_aero_realtime.py
+++ b/src/lmms_engine/models/aero_realtime/processing_aero_realtime.py
@@ -104,6 +104,7 @@ class AeroRealtimeProcessor(ProcessorMixin):
         "chat_template",
         "downsample_factor",
         "audio_length_per_tok",
+        "chunk_audio",
         "image_token",
         "video_token",
         "audio_token",
@@ -130,6 +131,7 @@ class AeroRealtimeProcessor(ProcessorMixin):
         chat_template=None,
         downsample_factor: int = 4,
         audio_length_per_tok: int = 8,
+        chunk_audio: bool = True,
         image_token: str = "<|image_pad|>",
         video_token: str = "<|video_pad|>",
         audio_token: str = "<|audio_pad|>",
@@ -174,6 +176,7 @@ class AeroRealtimeProcessor(ProcessorMixin):
         # Model config parameters needed for timestep computation
         self.downsample_factor = downsample_factor
         self.audio_length_per_tok = audio_length_per_tok
+        self.chunk_audio = bool(chunk_audio)
 
         if chat_template is None:
             chat_template = self.default_chat_template
@@ -473,45 +476,39 @@ class AeroRealtimeProcessor(ProcessorMixin):
         # ==============================================================
         # 8. Assemble output
         # ==============================================================
-        # Convert audio_attention_mask from mel-level (T_mel) to
-        # post-conv2 encoder length (T_enc = T_mel // 2) —
-        # this is what VoxtralRealtimeEncoder.forward expects as
-        # ``attention_mask``. Internal helpers above operated on the
-        # mel-level mask; downstream model code consumes the encoder-level mask.
+        # Emit audio features + post-conv2 encoder mask. Two modes:
+        #   - chunk_audio (default): pad T_mel to audio_length_per_tok, reshape
+        #     input_features into [B*N, F, chunk_mel] (one row per LM audio
+        #     token) and emit [B*N, chunk_enc] mask. With symmetric conv the
+        #     chunks are encoded independently.
+        #   - flat: keep [B, F, T_mel] and downsample mel_mask by 2 → [B, T_enc].
         if audio_inputs and "audio_attention_mask" in audio_inputs:
-            mel_mask = audio_inputs["audio_attention_mask"]
-            if not isinstance(mel_mask, torch.Tensor):
-                mel_mask = torch.as_tensor(mel_mask)
-            # Canonical T_mel comes from the mel feature tensor itself, not
-            # the FE attention_mask (which may be sample-grid-aligned and a
-            # few frames shorter than input_features due to reflection
-            # padding inside the FE).
-            input_features = audio_inputs.get("input_features", None)
-            if input_features is None:
-                T_mel = mel_mask.shape[-1]
+            feats = torch.as_tensor(audio_inputs["input_features"])
+            mel_mask = torch.as_tensor(audio_inputs["audio_attention_mask"])
+            # FE mask may lag input_features by a few reflection-pad frames; treat them as valid.
+            mel_mask = torch.nn.functional.pad(mel_mask, (0, feats.shape[-1] - mel_mask.shape[-1]), value=1)
+
+            if self.chunk_audio:
+                chunk_mel = self.audio_length_per_tok
+                chunk_enc = chunk_mel // 2
+                pad = (-feats.shape[-1]) % chunk_mel
+                feats = torch.nn.functional.pad(feats, (0, pad))
+                mel_mask = torch.nn.functional.pad(mel_mask, (0, pad))
+                B, F, T_mel = feats.shape
+                N = T_mel // chunk_mel
+                audio_inputs["input_features"] = (
+                    feats.view(B, F, N, chunk_mel).permute(0, 2, 1, 3).reshape(B * N, F, chunk_mel)
+                )
+                # A chunk is valid iff every mel frame in it is valid (matches floor div semantics).
+                chunk_valid = mel_mask.view(B, N, chunk_mel).all(-1)  # [B, N]
+                audio_inputs["audio_attention_mask"] = (
+                    chunk_valid.unsqueeze(-1).expand(B, N, chunk_enc).reshape(B * N, chunk_enc).long()
+                )
             else:
-                if not isinstance(input_features, torch.Tensor):
-                    input_features = torch.as_tensor(input_features)
-                T_mel = input_features.shape[-1]
-            mel_mask_len = mel_mask.shape[-1]
-            # Per-sample valid frame count in the mel feature. Add the
-            # constant pad offset (T_mel - mel_mask_len) to map valid
-            # FE-mask frames onto the mel grid.
-            pad_offset = max(0, T_mel - mel_mask_len)
-            mel_lengths_t = mel_mask.sum(-1).to(torch.long) + pad_offset
-            B = mel_mask.shape[0]
-            # Voxtral conv2: kernel=3, stride=2, left_pad=1 →
-            #   T_enc = (T_mel + left_pad - kernel) / stride + 1 = T_mel // 2
-            T_enc = T_mel // 2
-            enc_mask = torch.zeros(B, T_enc, dtype=torch.long)
-            for i in range(B):
-                m = int(mel_lengths_t[i].item())
-                # Clamp to T_mel (a sample's valid mel can't exceed full grid)
-                m = min(m, T_mel)
-                enc_m = m // 2 if m > 0 else 0
-                if enc_m > 0:
-                    enc_mask[i, :enc_m] = 1
-            audio_inputs["audio_attention_mask"] = enc_mask
+                T_enc = mel_mask.shape[-1] // 2
+                audio_inputs["audio_attention_mask"] = (
+                    mel_mask[:, : T_enc * 2].view(mel_mask.shape[0], T_enc, 2).all(-1).long()
+                )
 
         return BatchFeature(
             data={

--- a/src/lmms_engine/models/qwen3_vl_moe/monkey_patch.py
+++ b/src/lmms_engine/models/qwen3_vl_moe/monkey_patch.py
@@ -1,5 +1,6 @@
 from functools import partial, wraps
 
+from loguru import logger
 from packaging import version
 
 try:
@@ -154,3 +155,39 @@ def apply_liger_kernel_to_qwen3_vl_moe(
 
     # Always patch SparseMoeBlock forward (handles both < 5.0 and >= 5.0 via hasattr gate check)
     modeling_qwen3_vl_moe.Qwen3VLMoeTextSparseMoeBlock.forward = qwen3_vl_moe_moe_sparse_layer_forward
+
+
+@MONKEY_PATCHER.register("qwen3_vl_moe", "vit_frame_parallel")
+def apply_vit_frame_parallel_to_qwen3_vl_moe(model: PreTrainedModel = None, **kwargs) -> None:
+    """Wrap ``Qwen3VLMoeVisionModel.forward`` with DPxCP frame-parallel dispatch.
+
+    The MoE ViT is identical to the dense Qwen3-VL one, so the dense dispatch
+    ops are reused as-is.
+    """
+    from lmms_engine.models.qwen3_vl.qwen3_vl_vit_ops import (
+        input_dispatch,
+        output_dispatch,
+    )
+    from lmms_engine.parallel.vit_parallel.frame_parallel import wrap_vit_forward
+
+    if pgm.process_group_manager is None:
+        logger.info("vit_frame_parallel: process_group_manager not initialized, skipping ViT wrap")
+        return
+
+    dp_cp_world_size = pgm.process_group_manager.dp_cp_world_size
+    if dp_cp_world_size <= 1:
+        logger.info("vit_frame_parallel: dp_cp_world_size <= 1, skipping ViT wrap")
+        return
+
+    dp_cp_group = pgm.process_group_manager.dp_cp_group
+    cp_group = pgm.process_group_manager.cp_group if pgm.process_group_manager.cp_world_size > 1 else None
+
+    modeling_qwen3_vl_moe.Qwen3VLMoeVisionModel.forward = wrap_vit_forward(
+        input_dispatch=partial(input_dispatch, group=dp_cp_group, cp_group=cp_group),
+        orig_forward=modeling_qwen3_vl_moe.Qwen3VLMoeVisionModel.forward,
+        output_dispatch=output_dispatch,
+    )
+    logger.info(
+        f"vit_frame_parallel: wrapped Qwen3VLMoeVisionModel.forward "
+        f"(dp_cp_size={dp_cp_world_size}, cp_size={pgm.process_group_manager.cp_world_size})"
+    )

--- a/src/lmms_engine/models/utils.py
+++ b/src/lmms_engine/models/utils.py
@@ -36,6 +36,7 @@ VALID_CONFIG_TYPE = {
     "qwen3_5",
     "qwen3_vl",
     "qwen3_vl_moe",
+    "aero_realtime",
     "deepseek_v3",
     "minicpmv",
     "minicpmo",
@@ -75,6 +76,7 @@ class FlopsCounter:
             "qwen3_omni_moe_thinker": self._estimate_qwen2_moe_flops,
             "qwen3_vl": self._estimate_qwen2_flops,
             "qwen3_vl_moe": self._estimate_qwen2_moe_flops,
+            "aero_realtime": self._estimate_qwen2_flops,
             "deepseek_v3": self._estimate_deepseek_v3_flops,
             "minicpmv": self._estimate_qwen2_flops,
             "minicpmo": self._estimate_qwen2_flops,
@@ -93,6 +95,7 @@ class FlopsCounter:
             "qwen2_5_omni_thinker",
             "qwen3_omni_moe",
             "qwen3_omni_moe_thinker",
+            "aero_realtime",
         ]:
             self.config = config.text_config
             self.config.model_type = config.model_type

--- a/src/lmms_engine/models/utils.py
+++ b/src/lmms_engine/models/utils.py
@@ -77,6 +77,7 @@ class FlopsCounter:
             "qwen3_vl": self._estimate_qwen2_flops,
             "qwen3_vl_moe": self._estimate_qwen2_moe_flops,
             "aero_realtime": self._estimate_qwen2_flops,
+            "aero_realtime_moe": self._estimate_qwen2_moe_flops,
             "deepseek_v3": self._estimate_deepseek_v3_flops,
             "minicpmv": self._estimate_qwen2_flops,
             "minicpmo": self._estimate_qwen2_flops,
@@ -99,6 +100,13 @@ class FlopsCounter:
         ]:
             self.config = config.text_config
             self.config.model_type = config.model_type
+            if config.model_type == "aero_realtime":
+                from lmms_engine.models.aero_realtime.backbone_registry import (
+                    family_is_moe,
+                )
+
+                if family_is_moe(config.backbone_family):
+                    self.config.model_type = "aero_realtime_moe"
         elif config.model_type == "bagel":
             self.config = config.llm_config
         else:

--- a/src/lmms_engine/models/voxtral_realtime/__init__.py
+++ b/src/lmms_engine/models/voxtral_realtime/__init__.py
@@ -1,0 +1,3 @@
+from .monkey_patch import apply_rmpad_to_voxtral_realtime
+
+__all__ = ["apply_rmpad_to_voxtral_realtime"]

--- a/src/lmms_engine/models/voxtral_realtime/monkey_patch.py
+++ b/src/lmms_engine/models/voxtral_realtime/monkey_patch.py
@@ -1,0 +1,24 @@
+from loguru import logger
+from transformers import PreTrainedModel
+
+from lmms_engine.models.monkey_patch import MONKEY_PATCHER
+
+
+@MONKEY_PATCHER.register("voxtral_realtime_encoder", "rmpad")
+def apply_rmpad_to_voxtral_realtime(model: PreTrainedModel = None) -> None:
+    from transformers.models.voxtral_realtime.modeling_voxtral_realtime import (
+        VoxtralRealtimeAttention,
+        VoxtralRealtimeEncoder,
+    )
+
+    from .voxtral_realtime_ops import (
+        voxtral_realtime_attention_forward,
+        voxtral_realtime_encoder_forward,
+    )
+
+    if model is not None and not isinstance(model, VoxtralRealtimeEncoder):
+        raise TypeError(f"Expected VoxtralRealtimeEncoder, got {type(model)}")
+
+    VoxtralRealtimeEncoder.forward = voxtral_realtime_encoder_forward
+    VoxtralRealtimeAttention.forward = voxtral_realtime_attention_forward
+    logger.info("voxtral_realtime rmpad: patched encoder and attention forwards")

--- a/src/lmms_engine/models/voxtral_realtime/voxtral_realtime_ops.py
+++ b/src/lmms_engine/models/voxtral_realtime/voxtral_realtime_ops.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
+from transformers.modeling_outputs import BaseModelOutputWithPooling
+from transformers.models.voxtral_realtime.modeling_voxtral_realtime import (
+    VoxtralRealtimeAttention,
+    VoxtralRealtimeConv1dPaddingCache,
+    VoxtralRealtimeEncoder,
+    VoxtralRealtimeEncoderOutput,
+    apply_rotary_pos_emb,
+)
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs
+
+from lmms_engine.kernels.attention import varlen_attn
+from lmms_engine.parallel.sequence_parallel.ulysses import (
+    gather_heads_scatter_seq,
+    gather_outputs_and_unpad,
+    gather_seq_scatter_heads,
+    get_ulysses_sequence_parallel_world_size,
+    slice_input_tensor,
+    validate_ulysses_config,
+)
+
+
+def _get_unpad_data(attention_mask: torch.Tensor):
+    seqlens = attention_mask.sum(dim=-1, dtype=torch.int32)
+    indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
+    max_seqlen = seqlens.max().item()
+    cu_seqlens = F.pad(torch.cumsum(seqlens, dim=0, dtype=torch.int32), (1, 0))
+    return indices, cu_seqlens, max_seqlen
+
+
+def _pad_hidden_states(hidden_states: torch.Tensor, position_ids: torch.Tensor, sp_size: int):
+    pad_size = (sp_size - hidden_states.shape[0] % sp_size) % sp_size
+    if pad_size == 0:
+        return hidden_states, position_ids, pad_size
+
+    hidden_pad = hidden_states.new_zeros((pad_size, hidden_states.shape[-1]))
+    pos_pad = torch.arange(pad_size, dtype=position_ids.dtype, device=position_ids.device).unsqueeze(0)
+    return torch.cat([hidden_states, hidden_pad], dim=0), torch.cat([position_ids, pos_pad], dim=-1), pad_size
+
+
+def attention_forward(
+    self: VoxtralRealtimeAttention,
+    hidden_states: torch.Tensor,
+    position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    attention_mask: torch.Tensor | None,
+    past_key_values: Cache | None = None,
+    **kwargs: Unpack[FlashAttentionKwargs],
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    assert isinstance(attention_mask, dict), "VoxtralRealtime rmpad attention requires packed attention metadata"
+    return _varlen_attention_forward(
+        self,
+        hidden_states=hidden_states,
+        position_embeddings=position_embeddings,
+        cu_seq_lens=attention_mask["cu_seq_lens"],
+        max_seqlen=attention_mask["max_seqlen"],
+    )
+
+
+def _varlen_attention_forward(
+    self: VoxtralRealtimeAttention,
+    hidden_states: torch.Tensor,
+    position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    cu_seq_lens: torch.Tensor,
+    max_seqlen: int,
+) -> tuple[torch.Tensor, None]:
+    sp_size = get_ulysses_sequence_parallel_world_size()
+    total = hidden_states.shape[0]
+    query_states = self.q_proj(hidden_states).view(total, self.config.num_attention_heads, self.head_dim)
+    key_states = self.k_proj(hidden_states).view(total, self.config.num_key_value_heads, self.head_dim)
+    value_states = self.v_proj(hidden_states).view(total, self.config.num_key_value_heads, self.head_dim)
+
+    cos, sin = position_embeddings
+    query_states = query_states.transpose(0, 1).unsqueeze(0)
+    key_states = key_states.transpose(0, 1).unsqueeze(0)
+    query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+    query_states = query_states.squeeze(0).transpose(0, 1).contiguous()
+    key_states = key_states.squeeze(0).transpose(0, 1).contiguous()
+
+    if sp_size > 1:
+        validate_ulysses_config(query_states.size(1), sp_size)
+        query_states = gather_seq_scatter_heads(query_states, seq_dim=0, head_dim=1)
+        key_states = gather_seq_scatter_heads(key_states, seq_dim=0, head_dim=1)
+        value_states = gather_seq_scatter_heads(value_states, seq_dim=0, head_dim=1)
+
+    sliding_window = getattr(self.config, "sliding_window", None)
+    use_sliding_window = sliding_window is not None and max_seqlen > sliding_window
+    window_size = (sliding_window - 1, sliding_window - 1) if use_sliding_window else (-1, -1)
+    attn_output = varlen_attn(
+        query_states,
+        key_states,
+        value_states,
+        cu_seqlens_q=cu_seq_lens,
+        cu_seqlens_k=cu_seq_lens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_k=max_seqlen,
+        causal=True,
+        softmax_scale=self.scaling,
+        window_size=window_size,
+        dropout_p=0.0 if not self.training else self.attention_dropout,
+        backend=self.config._attn_implementation,
+    )
+    if sp_size > 1:
+        attn_output = gather_heads_scatter_seq(attn_output, seq_dim=0, head_dim=1)
+
+    attn_output = self.o_proj(attn_output.reshape(total, -1))
+    return attn_output, None
+
+
+def encoder_forward(
+    self: VoxtralRealtimeEncoder,
+    input_features: torch.FloatTensor | None = None,
+    position_ids: torch.LongTensor | None = None,
+    past_key_values: Cache | None = None,
+    padding_cache: VoxtralRealtimeConv1dPaddingCache | None = None,
+    inputs_embeds: torch.FloatTensor | None = None,
+    use_cache: bool | None = None,
+    use_padding_cache: bool | None = None,
+    attention_mask: torch.Tensor | None = None,
+    **kwargs: Unpack[TransformersKwargs],
+) -> tuple | BaseModelOutputWithPooling:
+    if (input_features is None) ^ (inputs_embeds is not None):
+        raise ValueError("You must specify exactly one of input_features or inputs_embeds")
+
+    if use_padding_cache and padding_cache is None:
+        padding_cache = VoxtralRealtimeConv1dPaddingCache()
+
+    if inputs_embeds is None:
+        inputs_embeds = self.embedder(input_features, padding_cache)
+
+    if use_cache and past_key_values is None:
+        past_key_values = DynamicCache(config=self.config)
+
+    if position_ids is None:
+        past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+        position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+        position_ids = position_ids.unsqueeze(0)
+
+    hidden_states = inputs_embeds
+    if attention_mask is None:
+        attention_mask = torch.ones(inputs_embeds.shape[:2], dtype=torch.long, device=inputs_embeds.device)
+    indices, cu_seq_lens, max_seqlen = _get_unpad_data(attention_mask)
+    hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])[indices]
+    position_ids = position_ids.expand(inputs_embeds.shape[0], -1).reshape(-1)[indices].unsqueeze(0)
+    sp_size = get_ulysses_sequence_parallel_world_size()
+    pad_size = 0
+    if sp_size > 1:
+        hidden_states, position_ids, pad_size = _pad_hidden_states(hidden_states, position_ids, sp_size)
+        hidden_states = slice_input_tensor(hidden_states, dim=0, padding=False)
+        position_ids = slice_input_tensor(position_ids, dim=-1, padding=False)
+        if pad_size > 0:
+            cu_seq_lens = torch.cat([cu_seq_lens, cu_seq_lens.new_tensor([cu_seq_lens[-1].item() + pad_size])])
+    causal_mask = {
+        "cu_seq_lens": cu_seq_lens,
+        "max_seqlen": max_seqlen,
+    }
+    position_embeddings = self.rotary_emb(hidden_states, position_ids=position_ids)
+
+    for encoder_layer in self.layers:
+        hidden_states = encoder_layer(
+            hidden_states,
+            attention_mask=causal_mask,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            **kwargs,
+        )
+
+    hidden_states = self.norm(hidden_states)
+    if sp_size > 1:
+        hidden_states = gather_outputs_and_unpad(hidden_states, gather_dim=0, unpad_dim=0, padding_size=pad_size)
+
+    return VoxtralRealtimeEncoderOutput(
+        last_hidden_state=hidden_states,
+        past_key_values=past_key_values,
+        padding_cache=padding_cache,
+    )
+
+
+voxtral_realtime_attention_forward = attention_forward
+voxtral_realtime_encoder_forward = encoder_forward
+
+__all__ = [
+    "attention_forward",
+    "encoder_forward",
+    "voxtral_realtime_attention_forward",
+    "voxtral_realtime_encoder_forward",
+]

--- a/src/lmms_engine/parallel/aero_realtime/__init__.py
+++ b/src/lmms_engine/parallel/aero_realtime/__init__.py
@@ -1,0 +1,3 @@
+from .parallelize import apply_aero_realtime_parallelize_fn
+
+__all__ = ["apply_aero_realtime_parallelize_fn"]

--- a/src/lmms_engine/parallel/aero_realtime/parallelize.py
+++ b/src/lmms_engine/parallel/aero_realtime/parallelize.py
@@ -1,0 +1,179 @@
+"""FSDP2 + Expert Parallel wiring for aero_realtime.
+
+aero_realtime owns ``language_model`` / ``vision_tower`` / ``audio_tower``
+/ ``multi_modal_projector`` / ``lm_head`` directly under the
+``AeroRealtimeForConditionalGeneration`` instance (no extra ``model.``
+wrapper, unlike qwen3_*_moe ForConditionalGeneration which nests
+decoder layers under ``model.model.language_model.layers``).
+
+For MoE backbone families (``qwen3_vl_moe``, ``qwen3_5_moe``) we apply
+expert-parallel to each language_model decoder layer's ``mlp.experts``,
+then FSDP2-shard per-submodule (attention block + MoE block) mirroring
+the inner family's parallelize fn. Dense families (``qwen3_vl``,
+``qwen3_5``) skip EP and fall through to FSDP2-only sharding.
+
+Mesh keys (from process_group_manager):
+- ``device_mesh["fsdp"]``           — flattened dp/cp mesh for FSDP
+- ``device_mesh["ep"]``             — EP mesh (only when ep_size>1)
+- ``device_mesh["dp_shard_mod_ep"]`` — expert-FSDP mesh (only when ep_size>1)
+"""
+
+from typing import TYPE_CHECKING
+
+import torch
+from loguru import logger
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
+from torch.distributed.tensor import Shard
+from torch.distributed.tensor.parallel import parallelize_module
+
+import lmms_engine.parallel.process_group_manager as pgm
+from lmms_engine.models.aero_realtime.backbone_registry import family_is_moe
+from lmms_engine.utils.fsdp2_utils import fsdp2_load_full_state_dict
+
+if TYPE_CHECKING:
+    from lmms_engine.train.config import TrainingArguments
+
+
+def _ep_style_cls(family: str):
+    """Return the family-appropriate ParallelStyle class for MoE experts."""
+    if family == "qwen3_vl_moe":
+        from lmms_engine.parallel.qwen3_vl_moe.style import Qwen3VLMoeParallelStyle
+
+        return Qwen3VLMoeParallelStyle
+    if family == "qwen3_5_moe":
+        from lmms_engine.parallel.qwen3_5_moe.style import Qwen3_5MoeParallelStyle
+
+        return Qwen3_5MoeParallelStyle
+    raise ValueError(f"no EP ParallelStyle for backbone_family={family}")
+
+
+def apply_aero_realtime_parallel(
+    model,
+    ep_mesh: DeviceMesh,
+    tp_mesh: DeviceMesh = None,
+    **kwargs,
+):
+    """Apply EP ParallelStyle to each language_model decoder layer's
+    ``mlp.experts``. Only meaningful for MoE backbone families."""
+    assert tp_mesh is None, "Tensor Parallelism is not supported yet for AeroRealtime"
+
+    family = model.config.backbone_family
+    if not family_is_moe(family):
+        raise ValueError(f"ep_degree>1 requires an MoE backbone_family; got {family}")
+
+    style_cls = _ep_style_cls(family)
+    num_moe_layers = 0
+    for decoder_layer in model.language_model.layers:
+        module = decoder_layer.mlp
+        parallelize_module(
+            module.experts,
+            device_mesh=ep_mesh,
+            parallelize_plan=style_cls(),
+        )
+        num_moe_layers += 1
+
+    logger.info(f"Applied {style_cls.__name__} to {num_moe_layers} aero_realtime MoE layers")
+
+
+def apply_aero_realtime_fsdp2(
+    model,
+    train_args: "TrainingArguments",
+    **kwargs,
+):
+    """FSDP2-shard aero_realtime per-submodule, mirroring qwen3_5_moe /
+    qwen3_vl_moe granularity but walking ``model.language_model.layers``
+    directly (no extra ``.model.`` wrapper)."""
+    if not train_args.fsdp_config.get("transformer_layer_cls_to_wrap", None):
+        logger.warning(
+            "transformer_layer_cls_to_wrap ignored; aero_realtime wraps decoder " "submodules (attn + mlp) explicitly."
+        )
+
+    if train_args.bf16:
+        param_dtype = torch.bfloat16
+    else:
+        param_dtype = torch.float16
+
+    if train_args.gradient_checkpointing:
+        model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+
+    reduce_dtype = getattr(torch, train_args.reduce_dtype)
+    output_dtype = getattr(torch, train_args.output_dtype)
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=param_dtype,
+        reduce_dtype=reduce_dtype,
+        output_dtype=output_dtype,
+    )
+
+    dp_mesh = pgm.process_group_manager.device_mesh["fsdp"]
+
+    fsdp_kwargs = {
+        "reshard_after_forward": getattr(train_args, "fsdp_config", {}).get("reshard_after_forward", True),
+        "mp_policy": mp_policy,
+        "mesh": dp_mesh,
+    }
+
+    family = model.config.backbone_family
+    is_moe = family_is_moe(family)
+    ep_size = pgm.process_group_manager.ep_size
+
+    expert_fsdp_kwargs = None
+    if ep_size > 1:
+
+        def _experts_shard_placement_fn(param):
+            return Shard(1)
+
+        expert_fsdp_kwargs = dict(fsdp_kwargs)
+        expert_fsdp_kwargs["mesh"] = pgm.process_group_manager.device_mesh["dp_shard_mod_ep"]
+        expert_fsdp_kwargs["shard_placement_fn"] = _experts_shard_placement_fn
+
+    # --- Towers / projector (aero-specific; qwen3_*_moe parallelize fns
+    # only wrap a single ``visual`` tower) ---
+    if getattr(model, "vision_tower", None) is not None:
+        fully_shard(model.vision_tower, **fsdp_kwargs)
+    if getattr(model, "audio_tower", None) is not None:
+        fully_shard(model.audio_tower, **fsdp_kwargs)
+    if getattr(model, "multi_modal_projector", None) is not None:
+        fully_shard(model.multi_modal_projector, **fsdp_kwargs)
+
+    # --- Decoder layers: per-submodule wrap (attn block + mlp / experts) ---
+    for decoder_layer in model.language_model.layers:
+        # MoE expert block — only for MoE families with ep_size>1
+        if is_moe and ep_size > 1:
+            fully_shard(decoder_layer.mlp, **expert_fsdp_kwargs)
+
+        # Attention block — qwen3_5 / qwen3_5_moe families have layer_type
+        # branching (linear_attention vs full_attention); qwen3_vl(_moe) do not.
+        layer_type = getattr(decoder_layer, "layer_type", None)
+        if layer_type == "linear_attention":
+            fully_shard(decoder_layer.linear_attn, **fsdp_kwargs)
+        else:
+            fully_shard(decoder_layer.self_attn, **fsdp_kwargs)
+
+    fully_shard(model.language_model.embed_tokens, **fsdp_kwargs)
+    fully_shard(model, **fsdp_kwargs)
+
+
+def apply_aero_realtime_parallelize_fn(
+    model,
+    train_args: "TrainingArguments",
+    **kwargs,
+):
+    """Entry registered as ``MODEL_TO_PARALLEL_METHOD['aero_realtime']``.
+
+    Mirrors the qwen3_5_moe / qwen3_vl_moe two-stage flow:
+      1. capture ``full_state_dict`` BEFORE parallelization
+      2. apply EP (if ep_size>1; requires MoE family)
+      3. apply FSDP2
+      4. reload full state dict into the now-sharded model
+    """
+    ep_size = pgm.process_group_manager.ep_size
+    full_state_dict = model.state_dict()
+
+    if ep_size > 1:
+        ep_mesh = pgm.process_group_manager.device_mesh["ep"]
+        apply_aero_realtime_parallel(model, ep_mesh=ep_mesh, **kwargs)
+
+    apply_aero_realtime_fsdp2(model, train_args, **kwargs)
+    fsdp2_load_full_state_dict(model, full_state_dict)
+    return model

--- a/src/lmms_engine/parallel/aero_realtime/parallelize.py
+++ b/src/lmms_engine/parallel/aero_realtime/parallelize.py
@@ -25,7 +25,11 @@ from loguru import logger
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 from torch.distributed.tensor import Shard
-from torch.distributed.tensor.parallel import parallelize_module
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    RowwiseParallel,
+    parallelize_module,
+)
 
 import lmms_engine.parallel.process_group_manager as pgm
 from lmms_engine.models.aero_realtime.backbone_registry import family_is_moe
@@ -48,32 +52,97 @@ def _ep_style_cls(family: str):
     raise ValueError(f"no EP ParallelStyle for backbone_family={family}")
 
 
+_QWEN3_VL_LIKE_TP_PLAN = {
+    "self_attn.q_proj": ColwiseParallel(use_local_output=True),
+    "self_attn.k_proj": ColwiseParallel(use_local_output=True),
+    "self_attn.v_proj": ColwiseParallel(use_local_output=True),
+    "self_attn.o_proj": RowwiseParallel(use_local_output=True),
+    "mlp.gate_proj": ColwiseParallel(use_local_output=True),
+    "mlp.up_proj": ColwiseParallel(use_local_output=True),
+    "mlp.down_proj": RowwiseParallel(use_local_output=True),
+}
+
+
+def _tp_plan_for_family(family: str):
+    """Return the per-decoder-layer TP plan for dense backbone families.
+
+    MoE families are handled via EP, not TP, so this only covers dense
+    families that ship a TP plan today (``qwen3_vl``). Add more dense
+    families here as their TP plans land.
+    """
+    if family == "qwen3_vl":
+        return _QWEN3_VL_LIKE_TP_PLAN
+    raise ValueError(f"no TP plan for backbone_family={family}")
+
+
+def _check_divisible(name: str, value: int, degree: int) -> None:
+    if value % degree != 0:
+        raise ValueError(f"{name} ({value}) must be divisible by tp_degree ({degree})")
+
+
+def _validate_aero_realtime_tp_config(model, tp_degree: int) -> None:
+    if tp_degree <= 1:
+        return
+
+    family = model.config.backbone_family
+    if family_is_moe(family):
+        raise ValueError(f"tp_degree>1 is not supported for MoE backbone_family={family}; use ep_degree instead")
+
+    # Dense families: validate text_config divisibility.
+    text_config = model.config.text_config
+    _check_divisible("hidden_size", text_config.hidden_size, tp_degree)
+    _check_divisible("intermediate_size", text_config.intermediate_size, tp_degree)
+    _check_divisible("num_attention_heads", text_config.num_attention_heads, tp_degree)
+    _check_divisible("num_key_value_heads", text_config.num_key_value_heads, tp_degree)
+
+    sp_degree = pgm.process_group_manager.cp_world_size
+    local_attention_heads = text_config.num_attention_heads // tp_degree
+    if sp_degree > 1 and local_attention_heads % sp_degree != 0:
+        raise ValueError(
+            f"num_attention_heads / tp_degree ({local_attention_heads}) must be divisible by "
+            f"sp_ulysses_degree ({sp_degree})"
+        )
+
+
 def apply_aero_realtime_parallel(
     model,
-    ep_mesh: DeviceMesh,
+    ep_mesh: DeviceMesh = None,
     tp_mesh: DeviceMesh = None,
     **kwargs,
 ):
-    """Apply EP ParallelStyle to each language_model decoder layer's
-    ``mlp.experts``. Only meaningful for MoE backbone families."""
-    assert tp_mesh is None, "Tensor Parallelism is not supported yet for AeroRealtime"
+    """Apply expert / tensor parallelism to the aero language_model.
 
+    - MoE families (``ep_mesh`` required): wrap each decoder layer's
+      ``mlp.experts`` with the family's ParallelStyle.
+    - Dense families (``tp_mesh`` required): apply the family's per-layer
+      TP plan to each decoder layer.
+    """
     family = model.config.backbone_family
-    if not family_is_moe(family):
-        raise ValueError(f"ep_degree>1 requires an MoE backbone_family; got {family}")
+    is_moe = family_is_moe(family)
 
-    style_cls = _ep_style_cls(family)
-    num_moe_layers = 0
+    if is_moe:
+        assert tp_mesh is None, f"tp_mesh not supported for MoE backbone_family={family}"
+        assert ep_mesh is not None, "ep_mesh required for MoE backbone family"
+
+        style_cls = _ep_style_cls(family)
+        num_moe_layers = 0
+        for decoder_layer in model.language_model.layers:
+            parallelize_module(
+                decoder_layer.mlp.experts,
+                device_mesh=ep_mesh,
+                parallelize_plan=style_cls(),
+            )
+            num_moe_layers += 1
+        logger.info(f"Applied {style_cls.__name__} to {num_moe_layers} aero_realtime MoE layers")
+        return
+
+    assert ep_mesh is None, f"ep_mesh not supported for dense backbone_family={family}"
+    assert tp_mesh is not None, "tp_mesh required for dense backbone family"
+
+    tp_plan = _tp_plan_for_family(family)
     for decoder_layer in model.language_model.layers:
-        module = decoder_layer.mlp
-        parallelize_module(
-            module.experts,
-            device_mesh=ep_mesh,
-            parallelize_plan=style_cls(),
-        )
-        num_moe_layers += 1
-
-    logger.info(f"Applied {style_cls.__name__} to {num_moe_layers} aero_realtime MoE layers")
+        parallelize_module(decoder_layer, device_mesh=tp_mesh, parallelize_plan=tp_plan)
+    logger.info(f"Applied {family} text TP to {len(model.language_model.layers)} aero_realtime decoder layers")
 
 
 def apply_aero_realtime_fsdp2(
@@ -163,16 +232,21 @@ def apply_aero_realtime_parallelize_fn(
 
     Mirrors the qwen3_5_moe / qwen3_vl_moe two-stage flow:
       1. capture ``full_state_dict`` BEFORE parallelization
-      2. apply EP (if ep_size>1; requires MoE family)
+      2. apply EP (MoE families, ep_size>1) or TP (dense families, tp_size>1)
       3. apply FSDP2
       4. reload full state dict into the now-sharded model
     """
     ep_size = pgm.process_group_manager.ep_size
+    tp_size = pgm.process_group_manager.tp_world_size
+    _validate_aero_realtime_tp_config(model, tp_size)
     full_state_dict = model.state_dict()
 
     if ep_size > 1:
         ep_mesh = pgm.process_group_manager.device_mesh["ep"]
         apply_aero_realtime_parallel(model, ep_mesh=ep_mesh, **kwargs)
+    elif tp_size > 1:
+        tp_mesh = pgm.process_group_manager.device_mesh["tp"]
+        apply_aero_realtime_parallel(model, tp_mesh=tp_mesh, **kwargs)
 
     apply_aero_realtime_fsdp2(model, train_args, **kwargs)
     fsdp2_load_full_state_dict(model, full_state_dict)

--- a/src/lmms_engine/parallel/parallelize.py
+++ b/src/lmms_engine/parallel/parallelize.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from lmms_engine.train.config import TrainingArguments
 
+from .aero_realtime.parallelize import apply_aero_realtime_parallelize_fn
 from .qwen3_5_moe.parallelize import apply_qwen3_5_moe_parallelize_fn
 from .qwen3_moe.parallelize import apply_qwen3_moe_parallelize_fn
 from .qwen3_omni_moe.parallelize import apply_qwen3_omni_moe_parallelize_fn
@@ -16,6 +17,7 @@ MODEL_TO_PARALLEL_METHOD = {
     "qwen3_omni_moe_thinker": apply_qwen3_omni_moe_parallelize_fn,
     "qwen3_vl": apply_qwen3_vl_parallelize_fn,
     "qwen3_vl_moe": apply_qwen3_vl_moe_parallelize_fn,
+    "aero_realtime": apply_aero_realtime_parallelize_fn,
 }
 
 

--- a/src/lmms_engine/utils/train_utils.py
+++ b/src/lmms_engine/utils/train_utils.py
@@ -91,14 +91,20 @@ class TrainUtilities:
         hf_messages = []
         for message in messages:
             new_message = {"role": message["role"], "content": []}
+            if "time" in message:
+                new_message["time"] = message["time"]
             for content in message["content"]:
-                if content["type"] == "image_url":
+                content_type = content.get("type")
+                if content_type == "image_url":
                     new_message["content"].append({"type": "image"})
-                elif content["type"] == "audio_url":
+                elif content_type == "audio_url":
                     new_message["content"].append({"type": "audio", "audio_url": content["audio_url"]["url"]})
-                elif content["type"] == "video_url":
+                elif content_type == "video_url":
                     new_message["content"].append({"type": "video", "video_url": content["video_url"]["url"]})
-                else:
+                elif content_type == "realtime_text":
+                    # Pass through realtime_text content for aero_realtime
+                    new_message["content"].append(content)
+                elif content.get("text") is not None:
                     new_content = {"type": "text", "text": content["text"]}
                     if "audio_text" in content:
                         new_content["audio_text"] = content["audio_text"]

--- a/src/lmms_engine/utils/train_utils.py
+++ b/src/lmms_engine/utils/train_utils.py
@@ -156,6 +156,8 @@ class TrainUtilities:
             flops = 148e12
         elif "910B" in device_name:
             flops = 354e12
+        elif "A6000" in device_name:
+            flops = 154.8e12
         elif "RTX 3070 Ti" in device_name:
             flops = 21.75e12
         flops_unit = unit_convert(flops, unit)

--- a/tools/convert_data/convert_llava_video_to_parquet.py
+++ b/tools/convert_data/convert_llava_video_to_parquet.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Convert LLaVA-Video-178K JSON data to lmms-engine parquet format.
+
+Reads the original LLaVA-Video-178K JSON files (ShareGPT format with
+``from``/``value`` keys and ``<image>`` as video placeholder) and converts
+them to the OpenAI-style message format expected by lmms-engine.
+
+Output parquet schema:
+    - ``id``: str  — sample identifier
+    - ``messages``: str (JSON)  — OpenAI-style chat messages
+
+Video paths in the output ``video_url`` are relative to the
+``data_folder`` specified in the training config.
+
+Usage:
+    python convert_llava_video_to_parquet.py \
+        --input_dir /data/v-kaichen/azure_blob/data/LLaVA-Video-178K \
+        --output_dir ./data/LLaVA-Video-178K \
+        --splits 0_30_s \
+        --max_per_split 0
+
+    ``--splits`` selects which duration buckets to include.
+    ``--max_per_split`` limits rows per source JSON (0 = no limit).
+"""
+
+import argparse
+import glob
+import json
+import os
+from typing import Dict, List
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+# ──────────────────────────────────────────────────────────────────────
+# Conversion helpers
+# ──────────────────────────────────────────────────────────────────────
+
+# System prompt for normal video QA — tells the model to watch the full
+# video in silence and only respond after the video ends and the user
+# asks a question.
+NORMAL_VIDEO_QA_SYSTEM_PROMPT = (
+    "You are a helpful video assistant. Watch the video carefully and "
+    "remain silent while it plays. Once the video ends and the user asks "
+    "a question, provide a clear and accurate answer."
+)
+
+
+def convert_sharegpt_to_openai(entry: dict) -> Dict:
+    """Convert a single ShareGPT-format entry to OpenAI message format.
+
+    The original format:
+        {"id": "...", "conversations": [{"from": "human", "value": "..."},
+         {"from": "gpt", "value": "..."}], "video": "path/to/video.mp4"}
+
+    The ``<image>`` token in the human turn is used as a video placeholder.
+    We convert it to a ``video_url`` content item.
+
+    A system message is prepended to instruct the model to stay silent
+    during video playback and answer only after the question is asked.
+    """
+    conversations = entry["conversations"]
+    video_path = entry.get("video", None)
+    entry_id = entry.get("id", "unknown")
+
+    messages: List[dict] = [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": NORMAL_VIDEO_QA_SYSTEM_PROMPT}],
+        }
+    ]
+    for turn in conversations:
+        role = "user" if turn["from"] == "human" else "assistant"
+        value = turn["value"]
+
+        content: List[dict] = []
+        if role == "user" and "<image>" in value:
+            # Replace <image> with video_url content item
+            # Strip the <image> and any surrounding whitespace/newlines
+            text = value.replace("<image>", "").strip()
+            text = text.lstrip("\n").strip()
+            if video_path is not None:
+                content.append(
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": video_path},
+                    }
+                )
+            if text:
+                content.append({"type": "text", "text": text})
+        else:
+            content.append({"type": "text", "text": value})
+
+        messages.append({"role": role, "content": content})
+
+    return {"id": str(entry_id), "messages": json.dumps(messages)}
+
+
+def process_json_file(json_path: str, max_rows: int = 0) -> List[dict]:
+    """Load a single LLaVA-Video JSON file and convert all entries."""
+    with open(json_path, "r") as f:
+        data = json.load(f)
+
+    if max_rows > 0:
+        data = data[:max_rows]
+
+    rows = []
+    for entry in data:
+        try:
+            row = convert_sharegpt_to_openai(entry)
+            rows.append(row)
+        except Exception as e:
+            print(f"  Skipping entry {entry.get('id', '?')}: {e}")
+    return rows
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert LLaVA-Video-178K to lmms-engine parquet")
+    parser.add_argument(
+        "--input_dir",
+        type=str,
+        default="/data/v-kaichen/azure_blob/data/LLaVA-Video-178K",
+        help="Root directory of LLaVA-Video-178K data",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="./data/LLaVA-Video-178K",
+        help="Output directory for parquet files",
+    )
+    parser.add_argument(
+        "--splits",
+        type=str,
+        nargs="+",
+        default=["0_30_s"],
+        help="Duration bucket prefixes to include (e.g. 0_30_s 30_60_s 1_2_m 2_3_m)",
+    )
+    parser.add_argument(
+        "--max_per_split",
+        type=int,
+        default=0,
+        help="Max rows per source JSON file (0 = no limit)",
+    )
+    parser.add_argument(
+        "--include_types",
+        type=str,
+        nargs="+",
+        default=["cap", "oe", "mc"],
+        help="Data types to include: cap (caption), oe (open-ended), mc (multi-choice)",
+    )
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # Find all JSON files matching the requested splits
+    all_json_files = []
+    for split_prefix in args.splits:
+        pattern = os.path.join(args.input_dir, f"{split_prefix}*", "*_processed.json")
+        matched = sorted(glob.glob(pattern))
+        all_json_files.extend(matched)
+
+    if not all_json_files:
+        print(f"No JSON files found for splits: {args.splits}")
+        print(f"Searched pattern: {args.input_dir}/<split>*/*_processed.json")
+        return
+
+    # Filter by include_types
+    filtered_files = []
+    for f in all_json_files:
+        basename = os.path.basename(f)
+        for t in args.include_types:
+            # Match patterns like *_cap_*, *_oe_*, *_mc_*
+            if f"_{t}_" in basename or f"_{t}." in basename:
+                filtered_files.append(f)
+                break
+
+    print(f"Found {len(filtered_files)} JSON files to convert:")
+    for f in filtered_files:
+        print(f"  {os.path.relpath(f, args.input_dir)}")
+
+    # Process all files
+    all_rows = []
+    for json_path in filtered_files:
+        rel_path = os.path.relpath(json_path, args.input_dir)
+        print(f"\nProcessing: {rel_path}")
+        rows = process_json_file(json_path, max_rows=args.max_per_split)
+        print(f"  -> {len(rows)} rows")
+        all_rows.extend(rows)
+
+    if not all_rows:
+        print("No rows converted.")
+        return
+
+    # Write to parquet
+    splits_tag = "_".join(args.splits)
+    types_tag = "_".join(args.include_types)
+    output_path = os.path.join(args.output_dir, f"llava_video_{splits_tag}_{types_tag}.parquet")
+
+    table = pa.table(
+        {
+            "id": pa.array([r["id"] for r in all_rows], type=pa.string()),
+            "messages": pa.array([r["messages"] for r in all_rows], type=pa.string()),
+        }
+    )
+
+    pq.write_table(table, output_path)
+    print(f"\nWrote {len(all_rows)} rows to {output_path}")
+    print(f"File size: {os.path.getsize(output_path) / 1024 / 1024:.1f} MB")
+
+    # Print a sample row for verification
+    sample = json.loads(all_rows[0]["messages"])
+    print(f"\nSample row (id={all_rows[0]['id']}):")
+    print(json.dumps(sample, indent=2)[:1000])
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/prepare_init_weight/prepare_aero_realtime.py
+++ b/tools/prepare_init_weight/prepare_aero_realtime.py
@@ -167,6 +167,9 @@ def main(args):
     vision_text_config = AutoConfig.from_pretrained(args.vision_model_id)
     text_config = vision_text_config.text_config
     vision_config = vision_text_config.vision_config
+    # Backbones declare tying at the top level only; the sub text_config falls
+    # back to its class default, which is wrong for e.g. Qwen3-VL-30B-A3B.
+    text_config.tie_word_embeddings = vision_text_config.tie_word_embeddings
 
     # ----- audio config: Qwen3-Omni layer dims + Qwen2-Audio mel + LayerNorm/GELU -----
     audio_config = AeroRealtimeAudioEncoderConfig(

--- a/tools/prepare_init_weight/prepare_aero_realtime.py
+++ b/tools/prepare_init_weight/prepare_aero_realtime.py
@@ -15,16 +15,17 @@
 """Prepare initial weights for AeroRealtime model.
 
 Initialises the AeroRealtime model from:
-- Vision tower: Qwen3-VL (e.g. Qwen/Qwen3-VL-4B-Instruct)
-- Audio tower: Qwen2Audio encoder (from Qwen/Qwen2-Audio-7B-Instruct)
-- Language model: Qwen3-VL text backbone (shared with vision model)
+- Vision tower: Qwen3 VL / Qwen3.5 (selected via --backbone_family)
+- Audio tower: VoxtralRealtimeEncoder (from mistralai/Voxtral-Mini-4B-Realtime-2602)
+- Language model: from the same vision+text source
 - Audio projector: randomly initialised
 
 Usage:
-    python tools/prepare_init_weight/prepare_aero_realtime.py \
-        --vision_model_id Qwen/Qwen3-VL-4B-Instruct \
-        --audio_model_id Qwen/Qwen2-Audio-7B-Instruct \
-        --output_dir ./data/aero_realtime_init
+    python tools/prepare_init_weight/prepare_aero_realtime.py \\
+        --backbone_family qwen3_5 \\
+        --vision_model_id Qwen/Qwen3.5-4B \\
+        --audio_model_id mistralai/Voxtral-Mini-4B-Realtime-2602 \\
+        --output_dir /path/to/aero_init
 """
 
 import argparse
@@ -38,8 +39,12 @@ from transformers import (
     AutoModelForImageTextToText,
     AutoProcessor,
     AutoTokenizer,
-    Qwen2AudioForConditionalGeneration,
-    WhisperFeatureExtractor,
+)
+from transformers.models.voxtral_realtime.feature_extraction_voxtral_realtime import (
+    VoxtralRealtimeFeatureExtractor,
+)
+from transformers.models.voxtral_realtime.modeling_voxtral_realtime import (
+    VoxtralRealtimeForConditionalGeneration,
 )
 
 from lmms_engine.models.aero_realtime.configuration_aero_realtime import (
@@ -74,7 +79,7 @@ def main(args):
         )
 
         print(f"Loading audio model from {args.audio_model_id}...")
-        audio_model = Qwen2AudioForConditionalGeneration.from_pretrained(
+        audio_model = VoxtralRealtimeForConditionalGeneration.from_pretrained(
             args.audio_model_id,
             torch_dtype="auto",
             device_map="cpu",
@@ -165,7 +170,7 @@ def main(args):
         print("Loading lm_head weights...")
         model.lm_head = vision_text_model.lm_head
 
-        # Load audio tower from Qwen2Audio
+        # Load audio tower from Voxtral
         print("Loading audio tower weights...")
         model.audio_tower = audio_model.audio_tower
 
@@ -219,11 +224,9 @@ def main(args):
     print("Building processor...")
     vision_processor = AutoProcessor.from_pretrained(args.vision_model_id)
 
-    # WhisperFeatureExtractor with 128 mel bins for Qwen2Audio compatibility
-    feature_extractor = WhisperFeatureExtractor(
-        feature_size=128,
-        sampling_rate=16000,
-    )
+    # Voxtral feature extractor — Whisper-style mel (128 bins, 10ms hop)
+    # with Voxtral-specific global_log_mel_max normalization.
+    feature_extractor = VoxtralRealtimeFeatureExtractor()
 
     processor = AeroRealtimeProcessor(
         image_processor=vision_processor.image_processor,
@@ -290,8 +293,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--audio_model_id",
         type=str,
-        default="Qwen/Qwen2-Audio-7B-Instruct",
-        help="HuggingFace model ID for the audio encoder (Qwen2Audio).",
+        default="mistralai/Voxtral-Mini-4B-Realtime-2602",
+        help="HuggingFace model ID for the audio encoder (Voxtral Realtime).",
     )
     parser.add_argument(
         "--output_dir",

--- a/tools/prepare_init_weight/prepare_aero_realtime.py
+++ b/tools/prepare_init_weight/prepare_aero_realtime.py
@@ -1,0 +1,316 @@
+# Copyright 2025 LMMs-Lab team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prepare initial weights for AeroRealtime model.
+
+Initialises the AeroRealtime model from:
+- Vision tower: Qwen3-VL (e.g. Qwen/Qwen3-VL-4B-Instruct)
+- Audio tower: Qwen2Audio encoder (from Qwen/Qwen2-Audio-7B-Instruct)
+- Language model: Qwen3-VL text backbone (shared with vision model)
+- Audio projector: randomly initialised
+
+Usage:
+    python tools/prepare_init_weight/prepare_aero_realtime.py \
+        --vision_model_id Qwen/Qwen3-VL-4B-Instruct \
+        --audio_model_id Qwen/Qwen2-Audio-7B-Instruct \
+        --output_dir ./data/aero_realtime_init
+"""
+
+import argparse
+import gc
+from pathlib import Path
+
+import torch
+from accelerate import init_empty_weights
+from transformers import (
+    AutoConfig,
+    AutoModelForImageTextToText,
+    AutoProcessor,
+    AutoTokenizer,
+    Qwen2AudioForConditionalGeneration,
+    WhisperFeatureExtractor,
+)
+
+from lmms_engine.models.aero_realtime.configuration_aero_realtime import (
+    AeroRealtimeConfig,
+)
+from lmms_engine.models.aero_realtime.modeling_aero_realtime import (
+    AeroRealtimeForConditionalGeneration,
+)
+from lmms_engine.models.aero_realtime.processing_aero_realtime import (
+    AeroRealtimeProcessor,
+)
+
+
+def main(args):
+    torch.set_default_dtype(torch.float16)
+
+    vision_text_config = AutoConfig.from_pretrained(args.vision_model_id)
+
+    if args.skip_weights:
+        print("--skip_weights set: only regenerating tokenizer / config / processor metadata.")
+        vision_text_model = None
+        # Load audio config without instantiating the heavy model
+        audio_config_full = AutoConfig.from_pretrained(args.audio_model_id)
+        audio_config = audio_config_full.audio_config
+        audio_model = None
+    else:
+        print(f"Loading vision/text model from {args.vision_model_id} (backbone_family={args.backbone_family})...")
+        vision_text_model = AutoModelForImageTextToText.from_pretrained(
+            args.vision_model_id,
+            torch_dtype="auto",
+            device_map="cpu",
+        )
+
+        print(f"Loading audio model from {args.audio_model_id}...")
+        audio_model = Qwen2AudioForConditionalGeneration.from_pretrained(
+            args.audio_model_id,
+            torch_dtype="auto",
+            device_map="cpu",
+        )
+        audio_config = audio_model.config.audio_config
+
+    # ----------------------------------------------------------------
+    # Build AeroRealtime config
+    # ----------------------------------------------------------------
+    text_config = vision_text_config.text_config
+    vision_config = vision_text_config.vision_config
+
+    # Resolve token indices from the Qwen3 VL tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(args.vision_model_id, use_fast=True)
+    # Qwen3 VL already has these special tokens
+    image_token_index = tokenizer.convert_tokens_to_ids("<|image_pad|>")
+    video_token_index = tokenizer.convert_tokens_to_ids("<|video_pad|>")
+
+    # Add new audio + realtime special tokens (in fixed id order)
+    from transformers import AddedToken
+
+    new_special_tokens = [
+        "<|audio_start|>",  # 151673
+        "<|audio_end|>",  # 151674
+        "<|audio_pad|>",  # 151675
+        "<|rt_start|>",
+        "<|rt_pad|>",
+        "<|rt_speak|>",
+        "<|rt_end|>",
+    ]
+    for tok in new_special_tokens:
+        if tok not in tokenizer.get_vocab():
+            tokenizer.add_tokens(AddedToken(tok, special=True, normalized=False), special_tokens=True)
+            print(f"Added {tok} token to tokenizer")
+
+    audio_token_index = tokenizer.convert_tokens_to_ids("<|audio_pad|>")
+    audio_start_token_index = tokenizer.convert_tokens_to_ids("<|audio_start|>")
+    audio_end_token_index = tokenizer.convert_tokens_to_ids("<|audio_end|>")
+    rt_start_token_index = tokenizer.convert_tokens_to_ids("<|rt_start|>")
+    rt_pad_token_index = tokenizer.convert_tokens_to_ids("<|rt_pad|>")
+    rt_speak_token_index = tokenizer.convert_tokens_to_ids("<|rt_speak|>")
+    rt_end_token_index = tokenizer.convert_tokens_to_ids("<|rt_end|>")
+
+    print(
+        f"Token indices: image={image_token_index}, video={video_token_index}, "
+        f"audio_pad={audio_token_index}, audio_start={audio_start_token_index}, "
+        f"audio_end={audio_end_token_index}"
+    )
+    print(
+        f"  rt_start={rt_start_token_index}, rt_pad={rt_pad_token_index}, "
+        f"rt_speak={rt_speak_token_index}, rt_end={rt_end_token_index}"
+    )
+
+    config = AeroRealtimeConfig(
+        text_config=text_config,
+        audio_config=audio_config,
+        vision_config=vision_config,
+        image_token_index=image_token_index,
+        video_token_index=video_token_index,
+        audio_token_index=audio_token_index,
+        audio_start_token_index=audio_start_token_index,
+        audio_end_token_index=audio_end_token_index,
+        rt_start_token_index=rt_start_token_index,
+        rt_pad_token_index=rt_pad_token_index,
+        rt_speak_token_index=rt_speak_token_index,
+        rt_end_token_index=rt_end_token_index,
+        downsample_factor=args.downsample_factor,
+        backbone_family=args.backbone_family,
+    )
+
+    # ----------------------------------------------------------------
+    # Create model and load weights (skipped when --skip_weights)
+    # ----------------------------------------------------------------
+    if not args.skip_weights:
+        print("Creating AeroRealtime model...")
+        with init_empty_weights():
+            model = AeroRealtimeForConditionalGeneration(config)
+
+        # Load vision tower from Qwen3 VL
+        print("Loading vision tower weights...")
+        model.vision_tower = vision_text_model.model.visual
+
+        # Load language model (Qwen3VLTextModel) from Qwen3 VL
+        print("Loading language model weights...")
+        model.language_model = vision_text_model.model.language_model
+
+        # Load lm_head from Qwen3 VL
+        print("Loading lm_head weights...")
+        model.lm_head = vision_text_model.lm_head
+
+        # Load audio tower from Qwen2Audio
+        print("Loading audio tower weights...")
+        model.audio_tower = audio_model.audio_tower
+
+        # Randomly init projector
+        print("Initialising audio projector...")
+        std = getattr(config.text_config, "initializer_range", 0.02)
+
+        # Re-create projector on CPU (not meta device)
+        from lmms_engine.models.aero_realtime.modeling_aero_realtime import (
+            AeroRealtimeMultiModalProjector,
+        )
+
+        model.multi_modal_projector = AeroRealtimeMultiModalProjector(config)
+        model.multi_modal_projector.linear_1.weight.data.normal_(mean=0.0, std=std)
+        model.multi_modal_projector.linear_2.weight.data.normal_(mean=0.0, std=std)
+
+        # ------------------------------------------------------------
+        # Handle vocab expansion for the new audio token
+        # ------------------------------------------------------------
+        orig_vocab_size = text_config.vocab_size
+        new_vocab_size = len(tokenizer)
+
+        if new_vocab_size > orig_vocab_size:
+            print(f"Expanding embeddings from {orig_vocab_size} to {new_vocab_size}...")
+            pad_shape = 64
+            model.resize_token_embeddings(new_vocab_size, pad_to_multiple_of=pad_shape)
+
+            # Initialise new token embeddings from the distribution of existing ones
+            pre_expansion_embeddings = model.language_model.embed_tokens.weight.data[:orig_vocab_size]
+            mu = torch.mean(pre_expansion_embeddings, dim=0).float()
+            n = pre_expansion_embeddings.size(0)
+            sigma = ((pre_expansion_embeddings - mu).T @ (pre_expansion_embeddings - mu)) / n
+            dist = torch.distributions.multivariate_normal.MultivariateNormal(mu, covariance_matrix=1e-5 * sigma)
+
+            num_new = model.language_model.embed_tokens.weight.data[orig_vocab_size:].shape[0]
+            model.language_model.embed_tokens.weight.data[orig_vocab_size:] = torch.stack(
+                [dist.sample() for _ in range(num_new)], dim=0
+            )
+            num_new_head = model.lm_head.weight.data[orig_vocab_size:].shape[0]
+            model.lm_head.weight.data[orig_vocab_size:] = torch.stack(
+                [dist.sample() for _ in range(num_new_head)], dim=0
+            )
+
+        model.eval()
+    else:
+        model = None
+
+    # ----------------------------------------------------------------
+    # Build processor
+    # ----------------------------------------------------------------
+    print("Building processor...")
+    vision_processor = AutoProcessor.from_pretrained(args.vision_model_id)
+
+    # WhisperFeatureExtractor with 128 mel bins for Qwen2Audio compatibility
+    feature_extractor = WhisperFeatureExtractor(
+        feature_size=128,
+        sampling_rate=16000,
+    )
+
+    processor = AeroRealtimeProcessor(
+        image_processor=vision_processor.image_processor,
+        video_processor=vision_processor.video_processor,
+        feature_extractor=feature_extractor,
+        tokenizer=tokenizer,
+        downsample_factor=args.downsample_factor,
+        rt_start_token="<|rt_start|>",
+        rt_pad_token="<|rt_pad|>",
+        rt_speak_token="<|rt_speak|>",
+        rt_end_token="<|rt_end|>",
+    )
+
+    # ----------------------------------------------------------------
+    # Save
+    # ----------------------------------------------------------------
+    output_path = Path(args.output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if model is not None:
+        print(f"Saving model to {args.output_dir}...")
+        model.save_pretrained(args.output_dir)
+    else:
+        print(f"Saving config only (no weights) to {args.output_dir}...")
+        config.save_pretrained(args.output_dir)
+    print(f"Saving processor to {args.output_dir}...")
+    processor.save_pretrained(args.output_dir)
+
+    # Print summary
+    if model is not None:
+        total_params = sum(p.numel() for p in model.parameters())
+        print(f"\nDone! Model saved to {args.output_dir}")
+        print(f"Total parameters: {total_params / 1e9:.2f}B")
+        print(f"  Vision tower: {sum(p.numel() for p in model.vision_tower.parameters()) / 1e6:.0f}M")
+        print(f"  Audio tower:  {sum(p.numel() for p in model.audio_tower.parameters()) / 1e6:.0f}M")
+        print(f"  Language model: {sum(p.numel() for p in model.language_model.parameters()) / 1e6:.0f}M")
+        print(f"  Audio projector: {sum(p.numel() for p in model.multi_modal_projector.parameters()) / 1e6:.1f}M")
+    else:
+        print(f"\nDone! Metadata (config + tokenizer + processor) saved to {args.output_dir}")
+        print("(model.safetensors untouched)")
+
+    # Clean up
+    del model, vision_text_model, audio_model, processor
+    torch.cuda.empty_cache()
+    gc.collect()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Prepare AeroRealtime initial weights")
+    parser.add_argument(
+        "--backbone_family",
+        type=str,
+        required=True,
+        choices=["qwen3_vl", "qwen3_vl_moe", "qwen3_5", "qwen3_5_moe"],
+        help="Backbone family for the vision+text source checkpoint. "
+        "Propagated into the generated AeroRealtimeConfig.",
+    )
+    parser.add_argument(
+        "--vision_model_id",
+        type=str,
+        default="Qwen/Qwen3-VL-4B-Instruct",
+        help="HuggingFace model ID for the vision+text backbone (Qwen3 VL).",
+    )
+    parser.add_argument(
+        "--audio_model_id",
+        type=str,
+        default="Qwen/Qwen2-Audio-7B-Instruct",
+        help="HuggingFace model ID for the audio encoder (Qwen2Audio).",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="./data/aero_realtime_init",
+        help="Directory to save the initialised model.",
+    )
+    parser.add_argument(
+        "--downsample_factor",
+        type=int,
+        default=4,
+        help="Audio downsampling factor for the projector.",
+    )
+    parser.add_argument(
+        "--skip_weights",
+        action="store_true",
+        help="Skip loading Qwen3-VL / Qwen2-Audio weights and saving model.safetensors. "
+        "Only regenerate tokenizer / config.json / processor_config.json / chat_template.",
+    )
+    args = parser.parse_args()
+
+    main(args)

--- a/tools/prepare_init_weight/prepare_aero_realtime.py
+++ b/tools/prepare_init_weight/prepare_aero_realtime.py
@@ -5,36 +5,41 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 """Prepare initial weights for AeroRealtime model.
 
-Initialises the AeroRealtime model from:
-- Vision tower: Qwen3 VL / Qwen3.5 (selected via --backbone_family)
-- Audio tower: VoxtralRealtimeEncoder (from mistralai/Voxtral-Mini-4B-Realtime-2602)
-- Language model: from the same vision+text source
-- Audio projector: randomly initialised
+Pulls submodule weights from independent sources:
 
-Usage:
+- Vision tower + language model: Qwen3 VL / Qwen3.5 (``--vision_model_id``)
+- Audio tower conv frontend: Qwen2-Audio (``--qwen2_audio_model_id``)
+- Audio tower transformer layers: Qwen3-Omni (``--qwen3_omni_model_id``)
+- Audio projector: random init
+
+Audio tower weights are pulled directly from safetensors shards (no full
+``from_pretrained``), so the 30B Qwen3-Omni checkpoint never gets fully
+loaded into memory.
+
+Example:
     python tools/prepare_init_weight/prepare_aero_realtime.py \\
-        --backbone_family qwen3_5 \\
-        --vision_model_id Qwen/Qwen3.5-4B \\
-        --audio_model_id mistralai/Voxtral-Mini-4B-Realtime-2602 \\
+        --backbone_family qwen3_vl \\
+        --vision_model_id Qwen/Qwen3-VL-4B-Instruct \\
+        --qwen2_audio_model_id Qwen/Qwen2-Audio-7B-Instruct \\
+        --qwen3_omni_model_id /path/to/Qwen3-Omni-30B-A3B-Instruct \\
+        --audio_padding_mode symmetric \\
         --output_dir /path/to/aero_init
 """
 
 import argparse
 import gc
+import json
 from pathlib import Path
 
 import torch
 from accelerate import init_empty_weights
+from huggingface_hub import snapshot_download
+from safetensors import safe_open
 from transformers import (
+    AddedToken,
     AutoConfig,
     AutoModelForImageTextToText,
     AutoProcessor,
@@ -43,68 +48,155 @@ from transformers import (
 from transformers.models.voxtral_realtime.feature_extraction_voxtral_realtime import (
     VoxtralRealtimeFeatureExtractor,
 )
-from transformers.models.voxtral_realtime.modeling_voxtral_realtime import (
-    VoxtralRealtimeForConditionalGeneration,
-)
 
 from lmms_engine.models.aero_realtime.configuration_aero_realtime import (
+    AeroRealtimeAudioEncoderConfig,
     AeroRealtimeConfig,
 )
 from lmms_engine.models.aero_realtime.modeling_aero_realtime import (
     AeroRealtimeForConditionalGeneration,
+    AeroRealtimeMultiModalProjector,
 )
 from lmms_engine.models.aero_realtime.processing_aero_realtime import (
     AeroRealtimeProcessor,
 )
+
+# ---------------------------------------------------------------------------
+# safetensors helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_local_dir(model_id_or_path: str) -> Path:
+    """Return a local directory for ``model_id_or_path``; download if needed."""
+    p = Path(model_id_or_path)
+    if p.exists() and p.is_dir():
+        return p
+    print(f"  snapshot_download({model_id_or_path}) ...")
+    return Path(snapshot_download(model_id_or_path, allow_patterns=["*.safetensors", "*.json"]))
+
+
+def _load_subset_from_safetensors(model_dir: Path, key_filter) -> dict[str, torch.Tensor]:
+    """Load only the tensors whose key passes ``key_filter(key) -> bool``.
+
+    Reads the safetensors index when present (sharded ckpt); falls back to
+    iterating shards directly when no index is found.
+    """
+    index_path = model_dir / "model.safetensors.index.json"
+    if index_path.exists():
+        weight_map = json.loads(index_path.read_text())["weight_map"]
+        shards: dict[str, list[str]] = {}
+        for key, shard in weight_map.items():
+            if key_filter(key):
+                shards.setdefault(shard, []).append(key)
+    else:
+        shards = {p.name: None for p in sorted(model_dir.glob("*.safetensors"))}
+
+    out: dict[str, torch.Tensor] = {}
+    for shard_name, keys in shards.items():
+        with safe_open(model_dir / shard_name, framework="pt", device="cpu") as f:
+            iter_keys = keys if keys is not None else [k for k in f.keys() if key_filter(k)]
+            for k in iter_keys:
+                out[k] = f.get_tensor(k)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# audio tower rename tables
+# ---------------------------------------------------------------------------
+
+
+def _build_audio_state_dict(
+    qwen2_audio_dir: Path,
+    qwen3_omni_dir: Path,
+) -> dict[str, torch.Tensor]:
+    """Assemble audio_tower state_dict: conv from Qwen2-Audio, layers from Qwen3-Omni."""
+
+    # --- conv frontend from Qwen2-Audio ---
+    print("Pulling conv frontend from Qwen2-Audio...")
+
+    def _q2a_filter(k: str) -> bool:
+        return k.startswith("audio_tower.conv1.") or k.startswith("audio_tower.conv2.")
+
+    q2a = _load_subset_from_safetensors(qwen2_audio_dir, _q2a_filter)
+    if not q2a:
+        raise RuntimeError(f"No audio_tower.conv* keys found in {qwen2_audio_dir}")
+
+    state: dict[str, torch.Tensor] = {}
+    for k, v in q2a.items():
+        # audio_tower.conv1.weight -> embedder.conv1.weight
+        new_k = k.replace("audio_tower.conv1.", "embedder.conv1.").replace("audio_tower.conv2.", "embedder.conv2.")
+        state[new_k] = v
+
+    # --- transformer layers + ln_post from Qwen3-Omni ---
+    print("Pulling transformer layers + ln_post from Qwen3-Omni...")
+    prefix = "thinker.audio_tower."
+
+    def _q3o_filter(k: str) -> bool:
+        if not k.startswith(prefix):
+            return False
+        tail = k[len(prefix) :]
+        return tail.startswith("layers.") or tail.startswith("ln_post.")
+
+    q3o = _load_subset_from_safetensors(qwen3_omni_dir, _q3o_filter)
+    if not q3o:
+        raise RuntimeError(f"No thinker.audio_tower.layers/ln_post keys found in {qwen3_omni_dir}")
+
+    for k, v in q3o.items():
+        tail = k[len(prefix) :]
+        # ln_post -> norm
+        if tail.startswith("ln_post."):
+            new_k = tail.replace("ln_post.", "norm.", 1)
+        else:
+            # layers.N.self_attn.out_proj.* -> layers.N.self_attn.o_proj.*
+            # layers.N.fc{1,2}.*           -> layers.N.mlp.fc{1,2}.*
+            new_k = tail.replace(".self_attn.out_proj.", ".self_attn.o_proj.")
+            new_k = new_k.replace(".fc1.", ".mlp.fc1.").replace(".fc2.", ".mlp.fc2.")
+        state[new_k] = v
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
 
 
 def main(args):
     torch.set_default_dtype(torch.float16)
 
     vision_text_config = AutoConfig.from_pretrained(args.vision_model_id)
-
-    if args.skip_weights:
-        print("--skip_weights set: only regenerating tokenizer / config / processor metadata.")
-        vision_text_model = None
-        # Load audio config without instantiating the heavy model
-        audio_config_full = AutoConfig.from_pretrained(args.audio_model_id)
-        audio_config = audio_config_full.audio_config
-        audio_model = None
-    else:
-        print(f"Loading vision/text model from {args.vision_model_id} (backbone_family={args.backbone_family})...")
-        vision_text_model = AutoModelForImageTextToText.from_pretrained(
-            args.vision_model_id,
-            torch_dtype="auto",
-            device_map="cpu",
-        )
-
-        print(f"Loading audio model from {args.audio_model_id}...")
-        audio_model = VoxtralRealtimeForConditionalGeneration.from_pretrained(
-            args.audio_model_id,
-            torch_dtype="auto",
-            device_map="cpu",
-        )
-        audio_config = audio_model.config.audio_config
-
-    # ----------------------------------------------------------------
-    # Build AeroRealtime config
-    # ----------------------------------------------------------------
     text_config = vision_text_config.text_config
     vision_config = vision_text_config.vision_config
 
-    # Resolve token indices from the Qwen3 VL tokenizer
+    # ----- audio config: Qwen3-Omni layer dims + Qwen2-Audio mel + LayerNorm/GELU -----
+    audio_config = AeroRealtimeAudioEncoderConfig(
+        hidden_size=1280,
+        intermediate_size=5120,
+        num_hidden_layers=32,
+        num_attention_heads=20,
+        num_key_value_heads=20,
+        head_dim=64,
+        num_mel_bins=128,
+        max_position_embeddings=1500,
+        activation_function="gelu",
+        norm_type="layer_norm",
+        mlp_type="gelu",
+        conv_padding=args.audio_padding_mode,
+        k_proj_bias=True,
+        sliding_window=None,
+        attention_window_left=-1,
+        attention_window_right=-1,
+    )
+
+    # ----- tokenizer + token indices -----
     tokenizer = AutoTokenizer.from_pretrained(args.vision_model_id, use_fast=True)
-    # Qwen3 VL already has these special tokens
     image_token_index = tokenizer.convert_tokens_to_ids("<|image_pad|>")
     video_token_index = tokenizer.convert_tokens_to_ids("<|video_pad|>")
 
-    # Add new audio + realtime special tokens (in fixed id order)
-    from transformers import AddedToken
-
     new_special_tokens = [
-        "<|audio_start|>",  # 151673
-        "<|audio_end|>",  # 151674
-        "<|audio_pad|>",  # 151675
+        "<|audio_start|>",
+        "<|audio_end|>",
+        "<|audio_pad|>",
         "<|rt_start|>",
         "<|rt_pad|>",
         "<|rt_speak|>",
@@ -113,7 +205,7 @@ def main(args):
     for tok in new_special_tokens:
         if tok not in tokenizer.get_vocab():
             tokenizer.add_tokens(AddedToken(tok, special=True, normalized=False), special_tokens=True)
-            print(f"Added {tok} token to tokenizer")
+            print(f"Added {tok}")
 
     audio_token_index = tokenizer.convert_tokens_to_ids("<|audio_pad|>")
     audio_start_token_index = tokenizer.convert_tokens_to_ids("<|audio_start|>")
@@ -122,16 +214,6 @@ def main(args):
     rt_pad_token_index = tokenizer.convert_tokens_to_ids("<|rt_pad|>")
     rt_speak_token_index = tokenizer.convert_tokens_to_ids("<|rt_speak|>")
     rt_end_token_index = tokenizer.convert_tokens_to_ids("<|rt_end|>")
-
-    print(
-        f"Token indices: image={image_token_index}, video={video_token_index}, "
-        f"audio_pad={audio_token_index}, audio_start={audio_start_token_index}, "
-        f"audio_end={audio_end_token_index}"
-    )
-    print(
-        f"  rt_start={rt_start_token_index}, rt_pad={rt_pad_token_index}, "
-        f"rt_speak={rt_speak_token_index}, rt_end={rt_end_token_index}"
-    )
 
     config = AeroRealtimeConfig(
         text_config=text_config,
@@ -150,84 +232,98 @@ def main(args):
         backbone_family=args.backbone_family,
     )
 
-    # ----------------------------------------------------------------
-    # Create model and load weights (skipped when --skip_weights)
-    # ----------------------------------------------------------------
-    if not args.skip_weights:
-        print("Creating AeroRealtime model...")
-        with init_empty_weights():
-            model = AeroRealtimeForConditionalGeneration(config)
+    if args.skip_weights:
+        print("--skip_weights: saving metadata only.")
+        output_path = Path(args.output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        config.save_pretrained(args.output_dir)
+        _save_processor(args, tokenizer)
+        return
 
-        # Load vision tower from Qwen3 VL
-        print("Loading vision tower weights...")
-        model.vision_tower = vision_text_model.model.visual
+    # ----- load vision+text model -----
+    print(f"Loading vision/text model from {args.vision_model_id}...")
+    vision_text_model = AutoModelForImageTextToText.from_pretrained(
+        args.vision_model_id, torch_dtype="auto", device_map="cpu"
+    )
 
-        # Load language model (Qwen3VLTextModel) from Qwen3 VL
-        print("Loading language model weights...")
-        model.language_model = vision_text_model.model.language_model
+    # ----- assemble audio tower state_dict from Qwen2-Audio + Qwen3-Omni -----
+    qwen2_audio_dir = _resolve_local_dir(args.qwen2_audio_model_id)
+    qwen3_omni_dir = _resolve_local_dir(args.qwen3_omni_model_id)
+    audio_state = _build_audio_state_dict(qwen2_audio_dir, qwen3_omni_dir)
 
-        # Load lm_head from Qwen3 VL
-        print("Loading lm_head weights...")
-        model.lm_head = vision_text_model.lm_head
+    # ----- build Aero model and graft submodules -----
+    print("Creating AeroRealtime model on meta device...")
+    with init_empty_weights():
+        model = AeroRealtimeForConditionalGeneration(config)
 
-        # Load audio tower from Voxtral
-        print("Loading audio tower weights...")
-        model.audio_tower = audio_model.audio_tower
+    print("Grafting vision tower / language model / lm_head...")
+    model.vision_tower = vision_text_model.model.visual
+    model.language_model = vision_text_model.model.language_model
+    model.lm_head = vision_text_model.lm_head
 
-        # Randomly init projector
-        print("Initialising audio projector...")
-        std = getattr(config.text_config, "initializer_range", 0.02)
+    print("Loading audio tower state_dict...")
+    # audio_tower is still on meta; materialise it first.
+    model.audio_tower.to_empty(device="cpu")
+    missing, unexpected = model.audio_tower.load_state_dict(audio_state, strict=False)
+    if unexpected:
+        raise RuntimeError(f"Unexpected keys when loading audio_tower: {unexpected[:8]}...")
+    # Anything missing must be either rotary_emb (no params) or a parameter we
+    # explicitly skipped — fail loudly if anything else slipped through.
+    bad_missing = [k for k in missing if "rotary_emb" not in k]
+    if bad_missing:
+        raise RuntimeError(f"Missing audio_tower keys after load: {bad_missing[:8]}...")
+    print(f"  audio_tower loaded ({len(audio_state)} tensors; {len(missing)} missing rotary buffers)")
 
-        # Re-create projector on CPU (not meta device)
-        from lmms_engine.models.aero_realtime.modeling_aero_realtime import (
-            AeroRealtimeMultiModalProjector,
+    print("Initialising audio projector (random)...")
+    model.multi_modal_projector = AeroRealtimeMultiModalProjector(config)
+    std = getattr(config.text_config, "initializer_range", 0.02)
+    model.multi_modal_projector.linear_1.weight.data.normal_(mean=0.0, std=std)
+    model.multi_modal_projector.linear_2.weight.data.normal_(mean=0.0, std=std)
+
+    # ----- vocab expansion -----
+    orig_vocab_size = text_config.vocab_size
+    new_vocab_size = len(tokenizer)
+    if new_vocab_size > orig_vocab_size:
+        print(f"Expanding embeddings {orig_vocab_size} -> {new_vocab_size}...")
+        model.resize_token_embeddings(new_vocab_size, pad_to_multiple_of=64)
+
+        pre = model.language_model.embed_tokens.weight.data[:orig_vocab_size]
+        mu = torch.mean(pre, dim=0).float()
+        n = pre.size(0)
+        sigma = ((pre - mu).T @ (pre - mu)) / n
+        dist = torch.distributions.multivariate_normal.MultivariateNormal(mu, covariance_matrix=1e-5 * sigma)
+
+        num_new = model.language_model.embed_tokens.weight.data[orig_vocab_size:].shape[0]
+        model.language_model.embed_tokens.weight.data[orig_vocab_size:] = torch.stack(
+            [dist.sample() for _ in range(num_new)], dim=0
         )
+        num_new_head = model.lm_head.weight.data[orig_vocab_size:].shape[0]
+        model.lm_head.weight.data[orig_vocab_size:] = torch.stack([dist.sample() for _ in range(num_new_head)], dim=0)
 
-        model.multi_modal_projector = AeroRealtimeMultiModalProjector(config)
-        model.multi_modal_projector.linear_1.weight.data.normal_(mean=0.0, std=std)
-        model.multi_modal_projector.linear_2.weight.data.normal_(mean=0.0, std=std)
+    model.eval()
 
-        # ------------------------------------------------------------
-        # Handle vocab expansion for the new audio token
-        # ------------------------------------------------------------
-        orig_vocab_size = text_config.vocab_size
-        new_vocab_size = len(tokenizer)
+    # ----- save -----
+    output_path = Path(args.output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    print(f"Saving model to {args.output_dir}...")
+    model.save_pretrained(args.output_dir)
+    _save_processor(args, tokenizer)
 
-        if new_vocab_size > orig_vocab_size:
-            print(f"Expanding embeddings from {orig_vocab_size} to {new_vocab_size}...")
-            pad_shape = 64
-            model.resize_token_embeddings(new_vocab_size, pad_to_multiple_of=pad_shape)
+    total = sum(p.numel() for p in model.parameters())
+    print(f"\nDone! Total params: {total / 1e9:.2f}B")
+    print(f"  Vision tower:    {sum(p.numel() for p in model.vision_tower.parameters()) / 1e6:.0f}M")
+    print(f"  Audio tower:     {sum(p.numel() for p in model.audio_tower.parameters()) / 1e6:.0f}M")
+    print(f"  Language model:  {sum(p.numel() for p in model.language_model.parameters()) / 1e6:.0f}M")
+    print(f"  Audio projector: {sum(p.numel() for p in model.multi_modal_projector.parameters()) / 1e6:.1f}M")
 
-            # Initialise new token embeddings from the distribution of existing ones
-            pre_expansion_embeddings = model.language_model.embed_tokens.weight.data[:orig_vocab_size]
-            mu = torch.mean(pre_expansion_embeddings, dim=0).float()
-            n = pre_expansion_embeddings.size(0)
-            sigma = ((pre_expansion_embeddings - mu).T @ (pre_expansion_embeddings - mu)) / n
-            dist = torch.distributions.multivariate_normal.MultivariateNormal(mu, covariance_matrix=1e-5 * sigma)
+    del model, vision_text_model
+    torch.cuda.empty_cache()
+    gc.collect()
 
-            num_new = model.language_model.embed_tokens.weight.data[orig_vocab_size:].shape[0]
-            model.language_model.embed_tokens.weight.data[orig_vocab_size:] = torch.stack(
-                [dist.sample() for _ in range(num_new)], dim=0
-            )
-            num_new_head = model.lm_head.weight.data[orig_vocab_size:].shape[0]
-            model.lm_head.weight.data[orig_vocab_size:] = torch.stack(
-                [dist.sample() for _ in range(num_new_head)], dim=0
-            )
 
-        model.eval()
-    else:
-        model = None
-
-    # ----------------------------------------------------------------
-    # Build processor
-    # ----------------------------------------------------------------
-    print("Building processor...")
+def _save_processor(args, tokenizer):
     vision_processor = AutoProcessor.from_pretrained(args.vision_model_id)
-
-    # Voxtral feature extractor — Whisper-style mel (128 bins, 10ms hop)
-    # with Voxtral-specific global_log_mel_max normalization.
     feature_extractor = VoxtralRealtimeFeatureExtractor()
-
     processor = AeroRealtimeProcessor(
         image_processor=vision_processor.image_processor,
         video_processor=vision_processor.video_processor,
@@ -239,39 +335,8 @@ def main(args):
         rt_speak_token="<|rt_speak|>",
         rt_end_token="<|rt_end|>",
     )
-
-    # ----------------------------------------------------------------
-    # Save
-    # ----------------------------------------------------------------
-    output_path = Path(args.output_dir)
-    output_path.mkdir(parents=True, exist_ok=True)
-
-    if model is not None:
-        print(f"Saving model to {args.output_dir}...")
-        model.save_pretrained(args.output_dir)
-    else:
-        print(f"Saving config only (no weights) to {args.output_dir}...")
-        config.save_pretrained(args.output_dir)
     print(f"Saving processor to {args.output_dir}...")
     processor.save_pretrained(args.output_dir)
-
-    # Print summary
-    if model is not None:
-        total_params = sum(p.numel() for p in model.parameters())
-        print(f"\nDone! Model saved to {args.output_dir}")
-        print(f"Total parameters: {total_params / 1e9:.2f}B")
-        print(f"  Vision tower: {sum(p.numel() for p in model.vision_tower.parameters()) / 1e6:.0f}M")
-        print(f"  Audio tower:  {sum(p.numel() for p in model.audio_tower.parameters()) / 1e6:.0f}M")
-        print(f"  Language model: {sum(p.numel() for p in model.language_model.parameters()) / 1e6:.0f}M")
-        print(f"  Audio projector: {sum(p.numel() for p in model.multi_modal_projector.parameters()) / 1e6:.1f}M")
-    else:
-        print(f"\nDone! Metadata (config + tokenizer + processor) saved to {args.output_dir}")
-        print("(model.safetensors untouched)")
-
-    # Clean up
-    del model, vision_text_model, audio_model, processor
-    torch.cuda.empty_cache()
-    gc.collect()
 
 
 if __name__ == "__main__":
@@ -281,39 +346,20 @@ if __name__ == "__main__":
         type=str,
         required=True,
         choices=["qwen3_vl", "qwen3_vl_moe", "qwen3_5", "qwen3_5_moe"],
-        help="Backbone family for the vision+text source checkpoint. "
-        "Propagated into the generated AeroRealtimeConfig.",
     )
+    parser.add_argument("--vision_model_id", type=str, default="Qwen/Qwen3-VL-4B-Instruct")
+    parser.add_argument("--qwen2_audio_model_id", type=str, default="Qwen/Qwen2-Audio-7B-Instruct")
+    parser.add_argument("--qwen3_omni_model_id", type=str, default="Qwen/Qwen3-Omni-30B-A3B-Instruct")
     parser.add_argument(
-        "--vision_model_id",
+        "--audio_padding_mode",
         type=str,
-        default="Qwen/Qwen3-VL-4B-Instruct",
-        help="HuggingFace model ID for the vision+text backbone (Qwen3 VL).",
+        default="symmetric",
+        choices=["causal", "symmetric"],
+        help="Conv padding mode for audio embedder.",
     )
-    parser.add_argument(
-        "--audio_model_id",
-        type=str,
-        default="mistralai/Voxtral-Mini-4B-Realtime-2602",
-        help="HuggingFace model ID for the audio encoder (Voxtral Realtime).",
-    )
-    parser.add_argument(
-        "--output_dir",
-        type=str,
-        default="./data/aero_realtime_init",
-        help="Directory to save the initialised model.",
-    )
-    parser.add_argument(
-        "--downsample_factor",
-        type=int,
-        default=4,
-        help="Audio downsampling factor for the projector.",
-    )
-    parser.add_argument(
-        "--skip_weights",
-        action="store_true",
-        help="Skip loading Qwen3-VL / Qwen2-Audio weights and saving model.safetensors. "
-        "Only regenerate tokenizer / config.json / processor_config.json / chat_template.",
-    )
+    parser.add_argument("--output_dir", type=str, default="./data/aero_realtime_init")
+    parser.add_argument("--downsample_factor", type=int, default=4)
+    parser.add_argument("--skip_weights", action="store_true")
     args = parser.parse_args()
 
     main(args)


### PR DESCRIPTION
## Summary
- add the standalone Aero Realtime multimodal model, processor, dataset, and collator
- add Aero-owned realtime audio encoder, rmpad/Liger integration, and FSDP2 parallelization
- support Qwen3-VL, Qwen3-VL MoE, Qwen3.5, and Qwen3.5 MoE backbones
- add checkpoint preparation, data conversion, and training examples

## Validation
- `python -m compileall` on Aero Realtime model, dataset, processor, parallel, and preparation modules
- import `AeroRealtimeConfig` and `AeroRealtimeForConditionalGeneration`
- `pre-commit run --all-files`
- `git diff --check origin/main...HEAD`